### PR TITLE
Require inbound ECS traffic to originate from VPC

### DIFF
--- a/config/develop/nextflow-ecs-security-group.yaml
+++ b/config/develop/nextflow-ecs-security-group.yaml
@@ -4,6 +4,7 @@ dependencies:
   - develop/nextflow-vpc.yaml
 parameters:
   VpcId: !stack_output_external nextflow-vpc::VPCId
+  SecurityGroupCidrIp: !stack_output_external nextflow-vpc::VpcCidr
 stack_tags:
   Department: IBC
   Project: Infrastructure

--- a/config/prod/nextflow-ecs-security-group.yaml
+++ b/config/prod/nextflow-ecs-security-group.yaml
@@ -4,6 +4,7 @@ dependencies:
   - prod/nextflow-vpc.yaml
 parameters:
   VpcId: !stack_output_external nextflow-vpc::VPCId
+  SecurityGroupCidrIp: !stack_output_external nextflow-vpc::VpcCidr
 stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
Currently, the ECS security group that's bound to the EC2 instances allows all traffic. This PR restricts that to traffic originating from the VPC, which includes the public load balancer that actually routes traffic to these instances. 

Sadly, we cannot easily use the load balancer's security group because that would introduce a circular dependency in the CloudFormation stacks. 