### PR TITLE
[WORKFLOWS-70] Create public buckets for iGenomes reference files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,10 @@ This repository uses the [Pipenv](https://pipenv.pypa.io/) Python package to man
 
 Additional dependencies exist for the [pre-commit hooks](.pre-commit-config.yaml) that we've added to this repository. The virtual environments for these hooks are automatically configured when you run `pre-commit`.
 
+### Scripts
+
+- `bin/mirror-igenomes.sh`: This Bash script is manually run to synchronize a subset of human and mouse reference files from the [nf-core iGenomes bucket](https://ewels.github.io/AWS-iGenomes/) to a Sage-owned bucket in `us-east-1`. There are multiple reasons: (1) Sage AWS accounts cannot make requests to regions outside of the US; (2) we don't want nf-core to incur egress charges on our behalf; (3) creating a local mirror in `us-east-1` should reduce latency; and (4) we own a copy of the reference files in case anything happens to the nf-core bucket (_e.g._ AWS funding being cut). At the moment, this script is intended to be run manually because reference files shouldn't change all that often and thus automating the process wasn't deemed worth the effort.
+
 ## Secrets
 
 The [CI/CD workflow](#cicd) and [Sceptre configurations](#configuration) make use of the following secrets.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Before you can use Nextflow Tower, you need to first deploy a Tower project, whi
 
 5. Log into Nextflow Tower using the [link](#access-nextflow-tower) at the top of this README and open your project workspace. If you were listed under `S3ReadWriteAccessArns`, then you'll be able to add pipelines to your workspace and launch them on your data.
 
+6. Acknowledge the following details:
+
+   - **Reference Files:** Sage Bionetworks has mirrored a subset of human and mouse reference files from the [nf-core iGenomes bucket](https://ewels.github.io/AWS-iGenomes/). These are found in the public `s3://sage-igenomes` S3 bucket, which **can only be accessed from the `us-east-1` region** (all other requests will be denied). If you're running nf-core pipelines, you should set the `--igenomes_base` parameter to `s3://sage-igenomes/igenomes`.
+
 ## License
 
 This repository is licensed under the [Apache License 2.0](LICENSE).

--- a/bin/mirror-igenomes.sh
+++ b/bin/mirror-igenomes.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# This script assumes that `AWS_PROFILE` has been set to a AWS CLI
+# profile that has write-access to the `s3://sage-igenomes` bucket
+# (or using any other means of authenticating with the AWS CLI).
+
 prefixes=(
     "Homo_sapiens/Ensembl/GRCh37"
     "Homo_sapiens/NCBI/GRCh38"

--- a/bin/mirror-igenomes.sh
+++ b/bin/mirror-igenomes.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+prefixes=(
+    "Homo_sapiens/Ensembl/GRCh37"
+    "Homo_sapiens/NCBI/GRCh38"
+    "Mus_musculus/Ensembl/GRCm38"
+    "Homo_sapiens/UCSC/hg38"
+    "Homo_sapiens/UCSC/hg19"
+    "Mus_musculus/UCSC/mm10"
+    "Homo_sapiens/GATK/GRCh37"
+    "Homo_sapiens/GATK/GRCh38"
+)
+
+for prefix in ${prefixes[*]}; do
+    echo "Syncing $prefix..."
+    mkdir -p "./$prefix/" \
+    && aws s3 --no-sign-request --region eu-west-1 sync "s3://ngi-igenomes/igenomes/$prefix/" "./$prefix/" \
+    && aws s3 --region us-east-1 sync "./$prefix/" "s3://sage-igenomes/igenomes/$prefix/" \
+    && rm -r "./$prefix/"
+done

--- a/config/develop/igenomes-bucket.yaml
+++ b/config/develop/igenomes-bucket.yaml
@@ -1,0 +1,12 @@
+template_path: public-bucket.yaml
+stack_name: igenomes-bucket
+
+parameters:
+  BucketName: "sage-igenomes-dev"
+  SameRegionResourceAccessToBucket: "true"
+  TemplateRootUrl: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com"
+
+stack_tags:
+  Department: "IBC"
+  Project: "Infrastructure"
+  OwnerEmail: "nextflow-admins@sagebase.org"

--- a/config/prod/igenomes-bucket.yaml
+++ b/config/prod/igenomes-bucket.yaml
@@ -1,0 +1,12 @@
+template_path: public-bucket.yaml
+stack_name: igenomes-bucket
+
+parameters:
+  BucketName: "sage-igenomes"
+  SameRegionResourceAccessToBucket: "true"
+  TemplateRootUrl: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com"
+
+stack_tags:
+  Department: "IBC"
+  Project: "Infrastructure"
+  OwnerEmail: "nextflow-admins@sagebase.org"

--- a/templates/public-bucket.yaml
+++ b/templates/public-bucket.yaml
@@ -1,0 +1,98 @@
+# Adapted from https://github.com/Sage-Bionetworks/aws-infra/blob/master/templates/s3-bucket-v2.j2
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Public (optionally region-restricted) bucket
+
+Parameters:
+  BucketName:
+    Type: String
+    Description: (Optional) Name of the created bucket.
+    Default: ""
+
+  SameRegionResourceAccessToBucket:
+    Type: String
+    Description: >
+      THIS CURRENTLY ONLY WORKS IN THE us-east-1 REGION!!!!!
+      Data transfers within the same region between AWS resources are free.
+      true to restrict downloading files from this bucket to only AWS resources (e.g. EC2 , Lambda) within the same region as this bucket.
+      This will not allow even the owner of the bucket to download objects in this bucket when not using an AWS resource in the same region!
+    AllowedValues:
+      - true
+      - false
+    Default: false
+
+  BucketVersioning:
+    Type: String
+    Description: Enabled to enable bucket versioning, default is Enabled
+    AllowedValues:
+      - Enabled
+      - Suspended
+    Default: Enabled
+
+  EnableDataLifeCycle:
+    Type: String
+    Description: Enabled to enable bucket lifecycle rule, default is Enabled
+    AllowedValues:
+      - Enabled
+      - Disabled
+    Default: Enabled
+
+  LifecycleDataTransition:
+    Type: Number
+    Description: Number of days until S3 objects are moved to LifecycleDataStorageClass
+    Default: 30
+
+  LifecycleDataStorageClass:
+    Type: String
+    Description: S3 bucket objects will transition into this storage class
+    AllowedValues:
+      - DEEP_ARCHIVE
+      - INTELLIGENT_TIERING
+      - STANDARD_IA
+      - ONEZONE_IA
+      - GLACIER
+    Default: INTELLIGENT_TIERING
+
+  TemplateRootUrl:
+    Type: String
+    Description: URL of S3 bucket where templates are deployed
+    ConstraintDescription: Must be a valid S3 HTTP URL
+
+Conditions:
+  HasBucketName: !Not [!Equals [!Ref BucketName, ""]]
+  CreateIPAddressRestrictionLambda:
+    !Equals [!Ref SameRegionResourceAccessToBucket, true]
+
+Resources:
+  PublicBucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      BucketName: !If [HasBucketName, !Ref BucketName, !Ref "AWS::NoValue"]
+      AccessControl: PublicRead
+      VersioningConfiguration:
+        Status: !Ref BucketVersioning
+      LifecycleConfiguration:
+        Rules:
+          - Id: DataLifecycleRule
+            Status: !Ref EnableDataLifeCycle
+            Transitions:
+              - TransitionInDays: !Ref LifecycleDataTransition
+                StorageClass: !Ref LifecycleDataStorageClass
+
+  IPAddressRestrictionLambda:
+    Type: "AWS::CloudFormation::Stack"
+    Condition: CreateIPAddressRestrictionLambda
+    Properties:
+      TemplateURL: !Sub ${TemplateRootUrl}/aws-infra/v0.3.2/AddSameRegionBucketDownloadRestriction.yaml
+      Parameters:
+        BucketName: !Ref PublicBucket
+
+Outputs:
+  PublicBucket:
+    Value: !Ref PublicBucket
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-PublicBucket"
+
+  PublicBucketArn:
+    Value: !GetAtt PublicBucket.Arn
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-PublicBucketArn"


### PR DESCRIPTION
I was hoping to re-use the `s3-bucket-v2.j2` template from aws-infra, but I didn't want to have to deal with the [S3objects macro](https://github.com/Sage-Bionetworks/aws-infra/tree/master/lambdas/cfn-s3objects-macro), especially because it's not relevant to our use case. I opted for adapting the template for our purposes. 

I'm still figuring out how to copy the files. Unfortunately, interacting with the nf-core bucket requires using `--no-sign-request`, which then prevents the requests to our bucket to work since they're unauthenticated (see example command below). I'm currently staging files locally on a Service Catalog instance. I included a script that I will run once the bucket is deployed to production. 

```console
aws s3 --no-sign-request sync "s3://source-bucket/" "s3://target-bucket/"
```