### PR TITLE
[WORKFLOWS-55 | WORKFLOWS-96] Upgrade Nextflow Tower to `v21.06.4`

### DIFF
--- a/config/develop/nextflow-ecs-task-definition.yaml
+++ b/config/develop/nextflow-ecs-task-definition.yaml
@@ -20,9 +20,9 @@ parameters:
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
   RedisContainerImage: 'redis:5.0.8'
-  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.0'
-  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v21.06.0'
-  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.0'
+  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.2'
+  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v21.06.2'
+  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.2'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerConfigFileName: 'tower.yaml'

--- a/config/develop/nextflow-ecs-task-definition.yaml
+++ b/config/develop/nextflow-ecs-task-definition.yaml
@@ -20,9 +20,9 @@ parameters:
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
   RedisContainerImage: 'redis:5.0.8'
-  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.2'
-  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v21.06.2'
-  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.2'
+  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.4'
+  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v21.06.4'
+  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.4'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerConfigFileName: 'tower.yaml'

--- a/config/prod/nextflow-ecs-task-definition.yaml
+++ b/config/prod/nextflow-ecs-task-definition.yaml
@@ -20,9 +20,9 @@ parameters:
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
   RedisContainerImage: 'redis:5.0.8'
-  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.0'
-  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v21.06.0'
-  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.0'
+  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.2'
+  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v21.06.2'
+  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.2'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerConfigFileName: 'tower.yaml'

--- a/config/prod/nextflow-ecs-task-definition.yaml
+++ b/config/prod/nextflow-ecs-task-definition.yaml
@@ -20,9 +20,9 @@ parameters:
   TowerGoogleClientId: !aws_secrets_manager nextflow/google_oauth_app::SecretString::client
   TowerGoogleSecret: !aws_secrets_manager nextflow/google_oauth_app::SecretString::secret
   RedisContainerImage: 'redis:5.0.8'
-  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.2'
-  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v21.06.2'
-  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.2'
+  CronContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.4'
+  FrontendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/frontend:v21.06.4'
+  BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v21.06.4'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
   TowerConfigFileName: 'tower.yaml'


### PR DESCRIPTION
I was originally waiting for a major release before upgrading Tower, but Paolo suggested this patch release might address the issue I reported [here](https://git.seqera.io/sage/nf-support/issues/7#issuecomment-6016). I already deployed this change to Nextflow-dev, and ECS transitioned to the new task definition as expected. I'm now running a test in Tower-dev to see whether the issue has been fixed or not. 

**Edit:** This PR now updates Tower to `v21.06.4`, which was released to address the following error message that I reported to Seqera. This requires compute environments to be re-created so their configuration can be updated. Hence, I've also updated the Tower configuration script to create versioned compute environments (instead of managing a default CE, which would be more complicated). The latest version is marked as the primary CE (aka the default). 

```
Error when retrieving credentials from container-role: Error retrieving metadata: Received error when attempting to retrieve ECS metadata: Connect timeout on endpoint URL: "http://169.254.170.2/v2/credentials/62307d39-2d77-4b25-b9e0-d08c257fe10a"
```

I'm also taking advantage of this update to the Tower configuration script to deploy a potential fix to WORKFLOWS-96, which has to do with running out of disk space despite EBS autoscaling being enabled. This seems to happen with large files 20-60 GB. Given that multiple jobs can run on a given instance, I suspect that the disk is running out of space before EBS autoscaling can kick in. I suspect that increasing the default EBS volume size from 100 GB (default) to 250 GB should mitigate this issue. 

I'm still confirming whether the aforementioned issues are fixed. That said, I think we can start the review in the meantime. 