### PR TITLE
Ensure that iGenomes reference files are public

### DIFF
--- a/bin/mirror-igenomes.sh
+++ b/bin/mirror-igenomes.sh
@@ -19,6 +19,6 @@ for prefix in ${prefixes[*]}; do
     echo "Syncing $prefix..."
     mkdir -p "./$prefix/" \
     && aws s3 --no-sign-request --region eu-west-1 sync "s3://ngi-igenomes/igenomes/$prefix/" "./$prefix/" \
-    && aws s3 --region us-east-1 sync "./$prefix/" "s3://sage-igenomes/igenomes/$prefix/" \
+    && aws s3 --region us-east-1 sync "./$prefix/" "s3://sage-igenomes/igenomes/$prefix/" --acl public-read \
     && rm -r "./$prefix/"
 done


### PR DESCRIPTION
I realized that setting the bucket ACL to `public-read` only allows unauthenticated users to list the bucket contents. It doesn't grant access to the objects themselves. I looked into granting public access to objects using a bucket policy, but this cannot be done without editing the Lambda function, which assigns and maintains the bucket policy. 

Instead, since the contents of the iGenomes bucket aren't expected to change very often, I opted to update all objects with the `public-read` ACL. This PR makes note of this requirement when mirroring iGenomes files, but I'm currently running the following command to retroactively deploy this change. From what I can tell, this does the trick. 

```
aws s3 cp s3://sage-igenomes/igenomes/ s3://sage-igenomes/igenomes/ --recursive --acl public-read --storage-class STANDARD
```