### PR TITLE
[WORKFLOWS-99] Switch to `BucketOwnerEnforced` object ownership setting

### DIFF
--- a/templates/tower-project.yaml
+++ b/templates/tower-project.yaml
@@ -224,11 +224,16 @@ Resources:
 
   TowerBucket:
     Type: AWS::S3::Bucket
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3030  # "BucketOwnerEnforced" isn't supported at the time of writing
     Properties:
       BucketName: !Sub "${AWS::StackName}-tower-bucket"
       OwnershipControls:
         Rules:
-          - ObjectOwnership: BucketOwnerPreferred
+          - ObjectOwnership: BucketOwnerEnforced
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: true
@@ -292,26 +297,13 @@ Resources:
               - !Sub "arn:aws:s3:::${TowerBucket}/*"
           - !If
             - HasS3ReadWriteAccessArns
-            - Sid: GrantWriteAccessToS3ReadWriteAccessArns
-              Effect: Allow
-              Principal:
-                AWS: !Ref S3ReadWriteAccessArns
-              Action:
-                - "s3:PutObject*"
-              Condition:
-                StringEquals:
-                  s3:x-amz-acl: bucket-owner-full-control
-              Resource:
-                - !Sub "arn:aws:s3:::${TowerBucket}/*"
-            - !Ref AWS::NoValue
-          - !If
-            - HasS3ReadWriteAccessArns
-            - Sid: GrantRemainingAccessToS3ReadWriteAccessArns
+            - Sid: GrantReadWriteAccessToS3ReadWriteAccessArns
               Effect: Allow
               Principal:
                 AWS: !Ref S3ReadWriteAccessArns
               Action:
                 - "s3:GetObject*"
+                - "s3:PutObject*"
                 - "s3:DeleteObject*"
                 - "s3:*MultipartUpload*"
                 - "s3:ListBucket*"


### PR DESCRIPTION
I propose that we switch to the new `BucketOwnerEnforced` setting for S3 object ownership. For more information, check out [these docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html). The gist is that objects uploaded by other AWS accounts (_e.g._ sandbox IAM roles) are automatically owned by the bucket owner, which ensures that the bucket policies are enforced on all objects. 

The big gain here is that users don't have to arbitrarily include the `--acl bucket-owner-full-control` option when uploading using the AWS CLI. Unfortunately, omitting this option results in a cryptic `Access Denied` error. Avoiding this error by getting rid of the requirement for the `bucket-owner-full-control` canned ACL will make Tower projects more user-friendly. 

- [ ] Once this is merged, I'll need to update the [Important Info](https://sagebionetworks.jira.com/wiki/spaces/WF/pages/2553970689/Nextflow+Tower+Important+Information#Uploading-Files) wiki accordingly. 