### PR TITLE
[WORKFLOWS-84] Provide default GitHub credentials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,7 @@ The following secrets were manually created in AWS Secrets Manager. They are use
 
 - `nextflow/license`: The paid license key for Nextflow Tower
 - `nextflow/google_oauth_app`: The Google OAuth client credentials
+- `nextflow/github_service_acct`: The GitHub service account credentials
 
 ## Additional Notes
 

--- a/config/common/cfn-s3objects-macro.yaml
+++ b/config/common/cfn-s3objects-macro.yaml
@@ -1,0 +1,7 @@
+template:
+  type: http
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/cfn-s3objects-macro/0.0.4/cfn-s3objects-macro.yaml"
+stack_name: cfn-s3objects-macro
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/config/develop/nextflow-tower-config-bucket.yaml
+++ b/config/develop/nextflow-tower-config-bucket.yaml
@@ -4,10 +4,8 @@ stack_name: {{ stack_name }}
 
 parameters:
   BucketName: {{ stack_name }}
+  GitHubUsername: !aws_secrets_manager nextflow/github_service_acct::SecretString::username
+  GitHubPassword: !aws_secrets_manager nextflow/github_service_acct::SecretString::password
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}
-
-hooks:
-  after_launch:
-    - !cmd "aws s3 cp tower-config/ s3://{{ stack_name }}/ --recursive"

--- a/config/prod/nextflow-tower-config-bucket.yaml
+++ b/config/prod/nextflow-tower-config-bucket.yaml
@@ -4,10 +4,8 @@ stack_name: {{ stack_name }}
 
 parameters:
   BucketName: {{ stack_name }}
+  GitHubUsername: !aws_secrets_manager nextflow/github_service_acct::SecretString::username
+  GitHubPassword: !aws_secrets_manager nextflow/github_service_acct::SecretString::password
 
 stack_tags:
   {{stack_group_config.default_stack_tags}}
-
-hooks:
-  after_launch:
-    - !cmd "aws s3 cp tower-config/ s3://{{ stack_name }}/ --recursive"

--- a/templates/nextflow-tower-config-bucket.yaml
+++ b/templates/nextflow-tower-config-bucket.yaml
@@ -1,11 +1,23 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: An S3 bucket readable by the account only
 
+Transform: S3Objects
+
 Parameters:
 
   BucketName:
     Type: String
     Description: Name of the created bucket.
+
+  GitHubUsername:
+    Type: String
+    Description: Username of GitHub service account
+    NoEcho: 'true'
+
+  GitHubPassword:
+    Type: String
+    Description: Password of GitHub service account
+    NoEcho: 'true'
 
 Resources:
 
@@ -32,6 +44,31 @@ Resources:
               AWS: !Sub '${AWS::AccountId}'
             Action: 's3:GetObject'
             Resource: !Sub 'arn:aws:s3:::${Bucket}/*'
+
+  TowerConfigFile:
+    Type: AWS::S3::Object
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3001
+    Properties:
+      Target:
+        Bucket: !Ref Bucket
+        Key: tower.yaml
+        ContentType: text
+      Body: !Sub |
+        tower:
+          auth:
+            google:
+              allow-list:
+                - "*@sagebase.org"
+                - "*@sagebionetworks.org"
+          scm:
+            providers:
+              github:
+                user: ${GitHubUsername}
+                password: ${GitHubPassword}
 
 Outputs:
 

--- a/tower-config/tower.yaml
+++ b/tower-config/tower.yaml
@@ -1,6 +1,0 @@
-tower:
-  auth:
-    google:
-      allow-list:
-        - "*@sagebase.org"
-        - "*@sagebionetworks.org"


### PR DESCRIPTION
Unfortunately, Nextflow Tower seems to issue plenty of requests to GitHub, which results in rate limits being imposed. These rate limits manifest in the form of uninformative errors like `Unknown pipeline repository or missing credentials`. In this PR, we are configuring Tower to authenticate requests to GitHub using a service account, which should have higher rate limits than unauthenticated requests. 

At the same time, I'm taking the opportunity to switch to using the `S3Objects` macro to obviate the need for a post-launch Sceptre hook. Shout-out to @tthyer for fixing the `S3Objects` macro! 