### PR TITLE
[WORKFLOWS-181] Create and add teams to Tower workspaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ The Nextflow Tower credentials (_i.e._ access tokens) were created manually usin
 - `CI_USER_ACCESS_KEY_ID`: The AWS access key ID for authenticating as an IAM CI service user.
 - `CI_USER_SECRET_ACCESS_KEY`: The AWS secret access key for authenticating as an IAM CI service user.
 - `CI_ROLE_TO_ASSUME`: The ARN of the IAM role that will be assumed after authenticating with the above IAM user credentials.
-- `TOWER_TOKEN`: The Nextflow Tower access token that will be used to provision the Tower workspaces, credentials, and compute environments.
+- `TOWER_TOKEN`: The Nextflow Tower access token that will be used to provision the Tower teams, workspaces, credentials, and compute environments.
 
 ### AWS Secrets
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Before you can use Nextflow Tower, you need to first deploy a Tower project, whi
 
    - A new Tower workspace called `<stack_name>` was created under this organization.
 
-   - Users listed under `S3ReadWriteAccessArns` were added as workspace participants with the `Maintain` role, which grants the following permissions:
+   - Users listed under `S3ReadWriteAccessArns` were added to a workspace team with the `Maintain` role, which grants the following permissions:
 
      > The users can launch pipeline and modify pipeline executions
        (e.g. can change the pipeline launch compute env, parameters,
@@ -63,7 +63,7 @@ Before you can use Nextflow Tower, you need to first deploy a Tower project, whi
        configuration in the Launchpad. The users cannot modify Compute
        env settings and Credentials
 
-   - Users listed under `S3ReadOnlyAccessArns` were added as workspace participants with the `View` role, which grants the following permissions:
+   - Users listed under `S3ReadOnlyAccessArns` were added to a workspace team with the `View` role, which grants the following permissions:
 
      > The users can access to the team resources in read-only mode
 

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -36,8 +36,7 @@ def main() -> None:
         )
     else:
         tower = TowerClient()
-        org = TowerOrganization(tower, projects)
-        org.create_workspaces()
+        TowerOrganization(tower, projects)
 
 
 class InvalidTowerProject(Exception):
@@ -383,12 +382,12 @@ class TowerWorkspace:
         return response["workspace"]
 
     def add_participant(self, role: str, user: str = None, team_id: int = None) -> int:
-        """Add user to the workspace (if need be) and return participant ID
+        """Add user or team to the workspace (if need be) and return participant ID
 
         Args:
             role (str): 'owner', 'admin', 'maintain', 'launch', or 'view'
-            user (str): Email address for the user
-            team_id (int): Team identifier
+            user (str): Email address for the user. Mutually exclusive with `team_id`.
+            team_id (int): Team identifier. Mutually exclusive with `user`.
 
         Returns:
             int: Participant ID for the user in the given workspace
@@ -617,6 +616,7 @@ class TowerOrganization:
         self.members: Dict[str, dict] = dict()
         self.populate()
         self.workspaces: Dict[str, TowerWorkspace] = dict()
+        self.create_workspaces()
 
     def create(self) -> dict:
         """Get or create Tower organization with the given name
@@ -745,9 +745,7 @@ class TowerOrganization:
         """
         endpoint = f"/orgs/{self.id}/teams/{team_id}/members"
         response = self.tower.request("GET", endpoint)
-        team_member_ids = list()
-        for team_member in response["members"]:
-            team_member_ids.append(team_member["memberId"])
+        team_member_ids = [member["memberId"] for member in response["members"]]
         return team_member_ids
 
     def populate(self) -> None:

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import argparse
+from collections import defaultdict
 import json
 import os
 import re
@@ -88,12 +89,13 @@ class Users:
         self.launchers = launchers
         self.viewers = viewers
 
-    def list_users(self) -> Iterator[Tuple[str, str]]:
+    def list_users(self) -> Iterator[Tuple[str, str, str]]:
         """List all users and their Tower roles
 
         Yields:
-            Iterator[Tuple[str, str]]:
-                Each element is the user email (str) and Tower role (str)
+            Iterator[Tuple[str, str, str]]:
+                Each element is the user email (str), the user group,
+                and Tower role (str)
         """
         role_mapping = {
             "owners": "owner",
@@ -105,7 +107,20 @@ class Users:
         for user_group, role in role_mapping.items():
             users = getattr(self, user_group)
             for user in users:
-                yield user, role
+                yield user, user_group, role
+
+    def list_teams(self) -> Iterator[Tuple[List[str], str, str]]:
+        """List all users grouped by their Tower roles
+
+        Yields:
+            Iterator[Tuple[List[str], str, str]]:
+                Each element is the list of user emails (List[str]),
+                the user group (str), and their Tower role (str)
+        """
+        teams = defaultdict(list)
+        for user, user_group, role in self.list_users():
+            teams[(user_group, role)].append(user)
+        return ((users, ugrp, role) for (ugrp, role), users in teams.items())
 
 
 class Projects:
@@ -326,7 +341,8 @@ class TowerWorkspace:
         self,
         org: TowerOrganization,
         stack_name: str,
-        users: Users,
+        users: Users = None,
+        teams: Dict[int, str] = None,
     ) -> None:
         self.org = org
         self.tower = org.tower
@@ -337,6 +353,7 @@ class TowerWorkspace:
         self.json = self.create()
         self.id = self.json["id"]
         self.users = users
+        self.teams = teams
         self.participants: Dict[str, dict] = dict()
         self.populate()
         self.create_compute_environment()
@@ -365,24 +382,38 @@ class TowerWorkspace:
         response = self.tower.request("POST", endpoint, json=data)
         return response["workspace"]
 
-    def add_participant(self, user: str, role: str) -> int:
+    def add_participant(self, role: str, user: str = None, team_id: int = None) -> int:
         """Add user to the workspace (if need be) and return participant ID
 
         Args:
-            user (str): Email address for the user
             role (str): 'owner', 'admin', 'maintain', 'launch', or 'view'
+            user (str): Email address for the user
+            team_id (int): Team identifier
 
         Returns:
             int: Participant ID for the user in the given workspace
         """
         # Attempt to add the user as a participant of the given workspace
         endpoint = f"/orgs/{self.org.id}/workspaces/{self.id}/participants"
-        member_id = self.org.members[user]["memberId"]
-        data = {
-            "memberId": member_id,
-            "teamId": None,
-            "userNameOrEmail": None,
-        }
+        if user and not team_id:
+            member_id = self.org.members[user]["memberId"]
+            identifier = member_id
+            data = {
+                "memberId": member_id,
+                "teamId": None,
+                "userNameOrEmail": None,
+            }
+        elif not user and team_id:
+            identifier = team_id
+            data = {
+                "memberId": None,
+                "teamId": team_id,
+                "userNameOrEmail": None,
+            }
+        else:
+            raise ValueError(
+                "Must provide value for exactly one of `user` or `team_id`."
+            )
         response = self.tower.request("PUT", f"{endpoint}/add", json=data)
         # If the user is already a member, you get the following message:
         #   "Already a participant"
@@ -390,12 +421,15 @@ class TowerWorkspace:
         if "message" in response and response["message"] == "Already a participant":
             response = self.tower.request("GET", endpoint)
             for participant in response["participants"]:
-                if participant["memberId"] == member_id:
+                if (
+                    participant.get("memberId") == identifier
+                    or participant.get("teamId") == identifier
+                ):
                     break
         # Otherwise, just return their new participant ID for the workspace
         else:
             participant = response["participant"]
-        self.participants[user] = participant
+        self.participants[identifier] = participant
         # Update participant role
         participant_id = participant["participantId"]
         self.set_participant_role(participant_id, role)
@@ -405,7 +439,7 @@ class TowerWorkspace:
         """Update the participant role in the given workspace
 
         Args:
-            part_id (int): Participant ID for the user
+            part_id (int): Participant ID for the user or team
             role (str): 'owner', 'admin', 'maintain', 'launch', or 'view'
         """
         endpoint = (
@@ -416,8 +450,12 @@ class TowerWorkspace:
 
     def populate(self) -> None:
         """Add maintainers and viewers to the organization and workspace"""
-        for user, role in self.users.list_users():
-            self.add_participant(user, role)
+        if self.users:
+            for user, _, role in self.users.list_users():
+                self.add_participant(role, user=user)
+        if self.teams:
+            for team_id, role in self.teams.items():
+                self.add_participant(role, team_id=team_id)
 
     def create_credentials(self) -> int:
         """Create entry for Forge credentials under the given workspace
@@ -575,6 +613,7 @@ class TowerOrganization:
         self.id = self.json["orgId"]
         self.projects = projects
         self.users_per_project = projects.users_per_project
+        self.teamids_per_project: Dict[str, Dict[int, str]] = dict()
         self.members: Dict[str, dict] = dict()
         self.populate()
         self.workspaces: Dict[str, TowerWorkspace] = dict()
@@ -640,15 +679,101 @@ class TowerOrganization:
         self.members[user] = member
         return member
 
+    def add_member_to_team(self, team_id: int, user: str) -> int:
+        """Add user to given team within an organization
+
+        Args:
+            team_id (int): Team identifier
+            user (str): Email address for the user
+
+        Returns:
+            int: Team member identifier, which is the same as the
+                organization member identifier
+        """
+        endpoint = f"/orgs/{self.id}/teams/{team_id}/members"
+        data = {"userNameOrEmail": user}
+        response = self.tower.request("POST", endpoint, json=data)
+        # If the user is already a member, you get the following message:
+        #   "The member is already associated with the team"
+        # If this happens, just retrieve the member ID from the organization
+        if "message" in response and "already" in response["message"]:
+            member = self.add_member(user)
+            member_id = member["memberId"]
+        else:
+            member_id = response["member"]["memberId"]
+        return member_id
+
+    def remove_member_from_team(self, team_id: int, member_id: int) -> Dict:
+        """Remove a member from an organization team
+
+        Args:
+            team_id (int): Team identifier
+            member_id (int): Member identifier
+        """
+        endpoint = f"/orgs/{self.id}/teams/{team_id}/members/{member_id}/delete"
+        response = self.tower.request("DELETE", endpoint)
+        return response
+
+    def create_team(self, team_name: str) -> int:
+        """Create team under organization with the given name
+
+        Args:
+            team_name (str): Team name
+
+        Returns:
+            int: Team identifier
+        """
+        # Check if the team already exists
+        endpoint = f"/orgs/{self.id}/teams"
+        response = self.tower.request("GET", endpoint)
+        for team in response["teams"]:
+            if team["name"] == team_name:
+                return team["teamId"]
+        # If team doesn't exist, create one
+        data = {"team": {"name": team_name, "description": None, "avatar": None}}
+        response = self.tower.request("POST", endpoint, json=data)
+        return response["team"]["teamId"]
+
+    def list_team_members(self, team_id: int) -> List[int]:
+        """Retrieve a list of team member IDs
+
+        Args:
+            team_id (int): Team identifier
+
+        Returns:
+            List[int]: List of team member IDs
+        """
+        endpoint = f"/orgs/{self.id}/teams/{team_id}/members"
+        response = self.tower.request("GET", endpoint)
+        team_member_ids = list()
+        for team_member in response["members"]:
+            team_member_ids.append(team_member["memberId"])
+        return team_member_ids
+
     def populate(self) -> None:
         """Add all emails from across all projects to the organization
 
         Returns:
             Dict[str, dict]: Same as self.project, but with member IDs
         """
-        for project_users in self.users_per_project.values():
-            for user, _ in project_users.list_users():
-                self.add_member(user)
+        for project_name, project_users in self.users_per_project.items():
+            # Create and populate teams for each user group/role
+            self.teamids_per_project[project_name] = dict()
+            for users, user_group, role in project_users.list_teams():
+                team_name = f"{project_name}-{user_group}"
+                team_id = self.create_team(team_name)
+                self.teamids_per_project[project_name][team_id] = role
+                # Add expected team members
+                verified_ids = set()
+                for user in users:
+                    member = self.add_member(user)
+                    member_id = member["memberId"]
+                    verified_ids.add(member_id)
+                    self.add_member_to_team(team_id, user)
+                # Remove unexpected team members
+                for team_member_id in self.list_team_members(team_id):
+                    if team_member_id not in verified_ids:
+                        self.remove_member_from_team(team_id, team_member_id)
 
     def list_projects(self) -> Iterator[Tuple[str, Users]]:
         """Iterate over all projects and their users
@@ -667,8 +792,9 @@ class TowerOrganization:
             Dict[str, TowerWorkspace]:
                 Mapping of project names and their corresponding workspaces
         """
-        for name, users in self.list_projects():
-            ws = TowerWorkspace(self, name, users)
+        for name, _ in self.list_projects():
+            teams = self.teamids_per_project[name]
+            ws = TowerWorkspace(self, name, teams=teams)
             self.workspaces[name] = ws
         return self.workspaces
 


### PR DESCRIPTION
We found that Tower users weren't getting access to the right workspaces. As a first-pass attempt to resolving this issue, I'm updating the Tower configuration script to create teams per project per role and adding these teams to the relevant workspaces. I'm also performing the additional step of removing unexpected users from each team to make sure they remain in sync with the Sceptre config file. 

I was able to test the updated script in Tower-dev. Once it's deployed to Tower-prod, I'm going to remove all of the users that are listed individually on workspaces. Because these users will have been added via a team, no one should suffer a lapse of access (unless they weren't supposed to have access to the workspace in the first place). 

**Edit:** As I show in [this comment](https://github.com/Sage-Bionetworks-Workflows/nextflow-infra/pull/96#issuecomment-1064220965), workspace participants with the `maintainer` role can add people to the workspace. I don't know if we can revoke this permission without affecting their ability to launch workflows. At the moment, the script ensures that the team membership is in sync with the Sceptre config file. Should we also make sure that no one else is added to the workspace as individual users (_i.e._ outside of a team)? 

## Organization Teams 

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/740725/157606882-97234fd1-f7ad-4e42-b9c7-1023c3debee8.png">

## Example Team

<img width="1418" alt="image" src="https://user-images.githubusercontent.com/740725/157606987-37c1f7b6-3ea3-40fe-a49f-6d207ba7b592.png">

## Teams Added to Workspace

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/740725/157606911-1d7b9c07-7932-4dd1-ba56-ac723f96d0c5.png">
