### PR TITLE
[WORKFLOWS-181] Ensure shorter team names due to length limit

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -93,7 +93,7 @@ jobs:
           interval: 10000
 
       - name: Configure projects in Tower
-        run: pipenv run bin/configure-tower-projects.py --debug config/projects-${{ matrix.sceptre-suffix }}
+        run: pipenv run bin/configure-tower-projects.py config/projects-${{ matrix.sceptre-suffix }}
         env:
           NXF_TOWER_TOKEN: ${{ secrets.TOWER_TOKEN }}
           NXF_TOWER_API_URL: ${{ matrix.tower-url }}/api

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Message us in the [`#workflow_users`](https://sagebionetworks.slack.com/archives
 
 Before you can use Nextflow Tower, you need to first deploy a Tower project, which consists of an encrypted S3 bucket and the IAM resources (_i.e._ users, roles, and policies) that Tower requires to access the encrypted bucket and execute the workflow on [AWS Batch](https://help.tower.nf/21.12/compute-envs/aws-batch/). Once these resources exist, they need to be configured in Nextflow Tower, which is a process that has been automated using CI/CD.
 
-1. Create a 'stack name' by following this naming convention: concatenate a project name with the suffix `-project` (_e.g._ `imcore-project`, `amp-ad-project`, `commonmind-project`).
+1. Create a 'stack name' by following this naming convention: concatenate a project name with the suffix `-project` (_e.g._ `imcore-project`, `amp-ad-project`, `commonmind-project`). Due to limits imposed by Tower, the stack name cannot contain more than 32 characters.
 
    **N.B.:** Anytime that `<stack_name>` appears below with the angle brackets, replace the placeholder with the actual stack name, omitting any angle brackets.
 

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -768,7 +768,8 @@ class TowerOrganization:
             # Create and populate teams for each user group/role
             self.teamids_per_project[project_name] = dict()
             for users, user_group, role in project_users.list_teams():
-                team_name = f"{project_name}-{user_group}"
+                project_prefix = project_name[:-8]  # Trim '-project' suffix
+                team_name = f"{project_prefix}-{user_group}"
                 team_id = self.create_team(team_name)
                 self.teamids_per_project[project_name][team_id] = role
                 # Add expected team members


### PR DESCRIPTION
I ran into the following error after merging #96 when creating the `challenge-infra-test-project-maintainers` team in Tower-prod. I've added a note to the README, and I'm trimming the `-project` suffix from the team name to compensate for the addition of the `-maintainers` or `-viewers` suffix. 

```
{'message': 'Team name must contain a minimum of 1 and a maximum of 38 alphanumeric characters separated by dashes or underscores'}
```

I'm disabling debug mode now that I figured out the issue with the #96 deployment. 