### PR TITLE
Add script for emptying an AWS Batch queue

### DIFF
--- a/bin/empty-queue.sh
+++ b/bin/empty-queue.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+JOB_QUEUE="${1}"
+NUM_CPUS="${2:-4}"
+
+for state in SUBMITTED PENDING RUNNABLE STARTING RUNNING
+do
+    aws batch list-jobs --job-queue "$JOB_QUEUE" --job-status "$state" --output 'text' --query 'jobSummaryList[*].[jobId]' \
+        | parallel --eta --jobs "$NUM_CPUS" 'aws batch terminate-job --reason "Terminating job." --job-id {}'
+done


### PR DESCRIPTION
I've ended up with AWS Batch job queues with thousands of jobs after cancelling a workflow run. Unfortunately, there's no way to empty a queue with one request. You need to terminate each job individually. This script uses GNU parallel to speed up the process. The script is based on this [AWS support article](https://aws.amazon.com/premiumsupport/knowledge-center/batch-jobs-termination/). 