### PR TITLE
Create `ntap-gdp5-project` stack

### DIFF
--- a/config/projects-prod/example-project.yaml
+++ b/config/projects-prod/example-project.yaml
@@ -1,6 +1,7 @@
 # (REQUIRED) Step 0: Duplicate this file and rename using the updated stack name (see Step 1)
 
 # (REQUIRED) Step 1: Update the stack name below by replacing "example" with your project name
+#                    Note that the stack name cannot contain more than 32 characters
 stack_name: example-project
 
 stack_tags:

--- a/config/projects-prod/ntap-add5-project.yaml
+++ b/config/projects-prod/ntap-add5-project.yaml
@@ -1,5 +1,5 @@
 template_path: tower-project.yaml
-stack_name: ntap-gdp5-project
+stack_name: ntap-add5-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml
   - common/nextflow-launch-iam-policy.yaml

--- a/config/projects-prod/ntap-gdp5-project.yaml
+++ b/config/projects-prod/ntap-gdp5-project.yaml
@@ -1,0 +1,23 @@
+template_path: tower-project.yaml
+stack_name: ntap-gdp5-project
+dependencies:
+  - common/nextflow-forge-iam-policy.yaml
+  - common/nextflow-launch-iam-policy.yaml
+
+parameters:
+  S3ReadWriteAccessArns:
+    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
+    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jineta.banerjee@sagebase.org
+    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org
+  AccountAdminArns:
+    - '{{stack_group_config.sso_admin_role.arn}}'
+    - !stack_output_external workflows-nextflow-ci-service-account::ServiceRoleArn
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
+  TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
+  TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+
+stack_tags:
+  Department: SCCE
+  Project: Neurofibromatosis
+  OwnerEmail: bruno.grande@sagebase.org
+  CostCenter: NO PROGRAM / 000000  # Will be updated once a program code is available


### PR DESCRIPTION
Naming is hard. Is `ntap-gdp5-project` intuitive? It's derived from the official project name, NTAP Genomic Data Processing, Addendum #5. Another option would be  `ntap-add5-project`. 