### PR TITLE
[WORKFLOWS-53] Fix auto-scaling for Tower ECS service

### DIFF
--- a/config/infra-dev/nextflow-ecs-service.yaml
+++ b/config/infra-dev/nextflow-ecs-service.yaml
@@ -7,6 +7,7 @@ dependencies:
 parameters:
   ClusterName: !stack_output_external nextflow-ecs-cluster::EcsClusterName
   TaskDefinitionArn: !stack_output_external nextflow-ecs-task-definition::TaskDefinitionArn
+  TowerCapacityProviderName: !stack_output_external nextflow-ecs-cluster::EcsCapacityProviderName
   TowerUIContainerName: !stack_output_external nextflow-ecs-task-definition::FrontendContainerName
   TowerUIContainerPort: !stack_output_external nextflow-ecs-task-definition::FrontendContainerPort
   VpcId: !stack_output_external nextflow-vpc::VPCId

--- a/templates/nextflow-ecs-cluster.yaml
+++ b/templates/nextflow-ecs-cluster.yaml
@@ -30,15 +30,16 @@ Parameters:
     Description: The VPC subnet where ECS instances will run.
 
   AutoscalingGroupMaxSize:
-    Type: Number
+    Type: String
     Description: (Optional) Limit on number of ECS cluster instances
-      Defaults to 1.
+      Defaults to 2.
     Default: '2'
 
   AutoscalingGroupDesiredCapacity:
-    Type: Number
+    Type: String
     Description: (Optional) Ideal number of ECS cluster instances
-    Default: '1'
+      Defaults to 0.
+    Default: '0'
 
   RootEbsVolumeSize:
     Type: Number
@@ -83,8 +84,8 @@ Resources:
           Status: ENABLED
           MinimumScalingStepSize: 1
           MaximumScalingStepSize: 1
-          TargetCapacity: 90
-        ManagedTerminationProtection: DISABLED
+          TargetCapacity: 100
+        ManagedTerminationProtection: ENABLED
 
   EcsRole:
     Type: AWS::IAM::Role
@@ -159,9 +160,7 @@ Resources:
       MinSize: '0'
       MaxSize: !Ref AutoscalingGroupMaxSize
       DesiredCapacity: !Ref AutoscalingGroupDesiredCapacity
-      TerminationPolicies:
-        - OldestLaunchConfiguration
-        - OldestInstance
+      NewInstancesProtectedFromScaleIn: true
       MetricsCollection:
         - Granularity: 1Minute
       Tags:
@@ -178,6 +177,11 @@ Outputs:
     Value: !Ref EcsCluster
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsClusterName'
+
+  EcsCapacityProviderName:
+    Value: !Ref EcsCapacityProvider
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsCapacityProviderName'
 
   EcsRoleArn:
     Value: !GetAtt EcsRole.Arn

--- a/templates/nextflow-ecs-service.yaml
+++ b/templates/nextflow-ecs-service.yaml
@@ -12,6 +12,10 @@ Parameters:
     Type: String
     Description: ARN for the ECS task definition that the ECS service uses
 
+  TowerCapacityProviderName:
+    Type: String
+    Description: Short name (not ARN) of ECS capacity provider for Tower
+
   VpcId:
     Description: ID of VPC
     Type: AWS::EC2::VPC::Id
@@ -141,7 +145,9 @@ Resources:
       DesiredCount: 1
       ServiceName: Nextflow-Tower-Service
       TaskDefinition: !Ref TaskDefinitionArn
-      LaunchType: EC2
+      CapacityProviderStrategy:
+        - CapacityProvider: !Ref TowerCapacityProviderName
+          Weight: 1
       Role: !Ref EcsServiceRole
       LoadBalancers:
       - ContainerName: !Ref TowerUIContainerName


### PR DESCRIPTION
I was working on #107 and I decided to take a stab at the auto-scaling issue we've been having with the Tower ECS service. Essentially, it would get stuck at two instances, even if the task was only running on a single instance. I implemented everything that was recommended by AWS Support in their latest response, and I think auto-scaling works as expected now. After launching the service, there were two instances, but after some time, that automatically dropped to a single instance. 

This will basically halve our EC2 costs for hosting Tower, which amounts to saving $10/day (or $300/mo). 

<img width="1653" alt="image" src="https://user-images.githubusercontent.com/740725/162374120-fe976355-2dc4-49bb-8d10-af563a0c8947.png">

Depends on #107 