### PR TITLE
Update maintenance stack with longer cron duration

### DIFF
--- a/config/common/maintenance.yaml
+++ b/config/common/maintenance.yaml
@@ -1,6 +1,6 @@
 template:
   type: http
-  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.3.8/templates/maintenance.yaml"
+  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.4.0/templates/maintenance.yaml"
 stack_name: maintenance
 
 stack_tags:


### PR DESCRIPTION
Version `v0.4.0` of aws-infra extended the duration of the maintenance stack cron jobs. @ahayden and @zaro0508 mentioned that I should be using this updated version. 