### PR TITLE
Disable private Tower workspaces per user

### DIFF
--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -25,6 +25,7 @@ parameters:
   BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.1.0'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
+  TowerUserWorkspace: 'false'
   TowerRootUsers:
     - bruno.grande@sagebase.org
     - tess.thyer@sagebase.org

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -25,6 +25,7 @@ parameters:
   BackendContainerImage: '195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/backend:v22.1.0'
   EfsFileSystemId: !stack_output_external nextflow-efs-file-system::FileSystemId
   EfsVolumeMountPath: '/efs'
+  TowerUserWorkspace: 'false'
   TowerRootUsers:
     - bruno.grande@sagebase.org
     - tess.thyer@sagebase.org

--- a/src/tower/resources/environment.yaml
+++ b/src/tower/resources/environment.yaml
@@ -20,4 +20,5 @@ TOWER_OIDC_SECRET: "!If [ HasTowerOidcClient, !Ref TowerOidcSecret, !Ref AWS::No
 TOWER_OIDC_ISSUER: "!If [ HasTowerOidcClient, !Ref TowerOidcIssuer, !Ref AWS::NoValue]"
 TOWER_OIDC_TOKEN_IMPORT: "!If [ HasTowerOidcClient, !Ref TowerOidcTokenImport, !Ref AWS::NoValue]"
 TOWER_ROOT_USERS: "!If [ HasTowerRootUsers, !Join [',', !Ref TowerRootUsers], !Ref AWS::NoValue]"
+TOWER_USER_WORKSPACE_ENABLED: "!Ref 'TowerUserWorkspace'"
 TOWER_CONFIG_FILE: "!Sub '${EfsVolumeMountPath}/${TowerConfigFileName}'"

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -150,7 +150,7 @@ Parameters:
     AllowedValues:
       - 'true'
       - 'false'
-    Default: 'false'
+    Default: 'true'
   AwslogsStreamPrefix:
     Type: String
     Description: Prefix used for CloudWatch log streams

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -144,6 +144,13 @@ Parameters:
       - 'true'
       - 'false'
     Default: 'false'
+  TowerUserWorkspace:
+    Type: String
+    Description: Whether to enable private Tower workspaces for each user
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Default: 'false'
   AwslogsStreamPrefix:
     Type: String
     Description: Prefix used for CloudWatch log streams
@@ -234,8 +241,8 @@ Resources:
             - Name: MICRONAUT_ENVIRONMENTS
               Value: !If
                 - HasTowerOidcClient
-                - prod,redis,cron,awsbatch-platform,auth-google,auth-oidc
-                - prod,redis,cron,awsbatch-platform,auth-google
+                - prod,redis,cron,workspace,awsbatch-platform,auth-google,auth-oidc
+                - prod,redis,cron,workspace,awsbatch-platform,auth-google
             {%- for name, value in sceptre_user_data.environment.items() %}
             - Name: {{ name }}
               Value: {{ value }}
@@ -291,8 +298,8 @@ Resources:
             - Name: MICRONAUT_ENVIRONMENTS
               Value: !If
                 - HasTowerOidcClient
-                - prod,redis,ha,awsbatch-platform,auth-google,auth-oidc
-                - prod,redis,ha,awsbatch-platform,auth-google
+                - prod,redis,ha,workspace,awsbatch-platform,auth-google,auth-oidc
+                - prod,redis,ha,workspace,awsbatch-platform,auth-google
             {%- for name, value in sceptre_user_data.environment.items() %}
             - Name: {{ name }}
               Value: {{ value }}


### PR DESCRIPTION
Disabling the user workspaces, which cannot be used anyways since they don't have credentials, will reduce user confusion. 