### PR TITLE
[WORKFLOWS-258] Block all public access on S3 buckets

### DIFF
--- a/config/infra-dev/s3-cfn-templates.yaml
+++ b/config/infra-dev/s3-cfn-templates.yaml
@@ -1,7 +1,0 @@
-template:
-  type: http
-  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.2.3/templates/S3/public-bucket.yaml"
-stack_name: "cloudformation-templates"
-
-stack_tags:
-  {{stack_group_config.default_stack_tags}}

--- a/templates/nextflow-tower-config-bucket.yaml
+++ b/templates/nextflow-tower-config-bucket.yaml
@@ -30,6 +30,11 @@ Resources:
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
 
   BucketPolicy:
     Type: AWS::S3::BucketPolicy

--- a/templates/tower-project.yaml
+++ b/templates/tower-project.yaml
@@ -263,6 +263,11 @@ Resources:
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: true
@@ -379,6 +384,11 @@ Resources:
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: true


### PR DESCRIPTION
CloudFormation defaults to **not** blocking public access on S3 buckets. This PR addresses that for public that ought not to be public. 