### PR TITLE
[WORKFLOWS-293] Mitigate issue with orphaned EBS volumes (and upgrade Tower)

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -592,8 +592,8 @@ class TowerWorkspace:
                     "headJobRole": self.stack["TowerForgeBatchHeadJobRoleArn"],
                     "executionRole": self.stack["TowerForgeBatchExecutionRoleArn"],
                     "headJobCpus": None,
-                    "headJobMemoryMb": 7168,
-                    "preRunScript": "NXF_OPTS='-Xms1g -Xmx4g'",
+                    "headJobMemoryMb": 15360,
+                    "preRunScript": "NXF_OPTS='-Xms4g -Xmx12g'",
                     "postRunScript": None,
                     "cliPath": None,
                     "forge": {
@@ -606,7 +606,11 @@ class TowerWorkspace:
                         "maxCpus": 1000,
                         "gpuEnabled": False,
                         "ebsAutoScale": True,
-                        "allowBuckets": ["s3://sage-igenomes"],
+                        "allowBuckets": [
+                            f"s3://{self.stack['TowerBucket']}",
+                            f"s3://{self.stack['TowerScratch']}",
+                            "s3://sage-igenomes",
+                        ],
                         "disposeOnDeletion": True,
                         "instanceTypes": [],
                         "allocStrategy": None,

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -15,7 +15,7 @@ import yaml  # type: ignore
 
 
 # Increment this version when updating compute environments
-CE_VERSION = "v4"
+CE_VERSION = "v5"
 
 REGION = "us-east-1"
 ORG_NAME = "Sage Bionetworks"
@@ -613,8 +613,8 @@ class TowerWorkspace:
                         "ec2KeyPair": None,
                         "imageId": None,
                         "securityGroups": [],
-                        "ebsBlockSize": 250,
-                        "fusionEnabled": False,
+                        "ebsBlockSize": 1000,
+                        "fusionEnabled": True,
                         "efsCreate": False,
                         "bidPercentage": None,
                     },

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -606,7 +606,7 @@ class TowerWorkspace:
                         "maxCpus": 1000,
                         "gpuEnabled": False,
                         "ebsAutoScale": True,
-                        "allowBuckets": [],
+                        "allowBuckets": ["s3://sage-igenomes"],
                         "disposeOnDeletion": True,
                         "instanceTypes": [],
                         "allocStrategy": None,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v22.1.3
+tower_version: v22.1.5
 default_stack_tags:
   Department: IBC
   Project: Infrastructure

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@ profile: {{ var.profile | default() }}
 region: {{ var.region | default("us-east-1") }}
 aws_infra_templates_root_url: https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
-tower_version: v22.1.1
+tower_version: v22.1.3
 default_stack_tags:
   Department: IBC
   Project: Infrastructure


### PR DESCRIPTION
This PR aims to mitigate the issue with EBS auto-scaling that results in orphaned EBS volumes. Two strategies are employed:

- **Enable Fusion mounts for relevant S3 buckets:** The main advantage with this strategy is that parallel jobs on an AWS Batch EC2 instance will not download the same files in parallel (if applicable). Instead, they will read the files from a common source, which should slow down how much the EBS volumes grow. 
- **Increase initial EBS volume size:** This strategy should buy some time before the volume needs to be auto-scaled. This would hopefully result in fewer auto-scaling events happening within seconds of each other, which in turn risks triggering EC2 API rate limits. 

Since we're upgrading the CE version, I'm also upgrading the Tower version and another bit of CE configuration to avoid a separate version bump. The additional tweaks are: 

- **Upgrade Tower version:** See below for changelog. The highlights are that workspace maintainers can now create workspace secrets and the default version of Nextflow includes a bug fix affecting the new handling of spot termination. 
- **Increase head job memory:** I ran into memory issues running large workflows with tens of thousands of parallel jobs, so this will hopefully prevent that issue from re-occurring. 

## Tower Changelog

```
22.1.5 - 7 Jun 2022
- Fix perms for encrypted bucket [96f00f39]
- Add the support for USR2 signal to launcher script [40c4ab68]

22.1.4 - 1 Jun 2022
- Enable maintainers to create workspace secrets [2d1a225f]
- Forward revision when creating a pipeline (#3203) [2ff2f171]
- Change MOAB queue status command (#3219) [4eda7f90]

22.1.3 - 18 May 2022
- Update Nextflow to 22.04.3
- Bump nf-launcher:j17-22.04.3
- Bump nf-jdk:corretto-11.0.15_up1

22.1.2 - 9 May 2022
- fix: Add KMS permissions required by EBS autoscale with encrypted volumes [387ed6c3]
- fix: Update HTTP content security policy to allow host URLs for frames and workers [327b27ac]
- fix: Minor navigation error when removing not existent CSV renderer component [a501225c]
- fix: Issue downloading a report with containing a blank character [70ab2033]
- fix: Nginx proxy pass decoding break query parameters with blank character [48a2ef6b]
- fix: Kubernetes control plan URL only allow host name [1b4b1240] [da552afc]
- Bump ebs-autoscale to version 2.4.6-6ce65d32 [d52de172]
```