### PR TITLE
Shell script for configuring SSH via SSM

### DIFF
--- a/bin/setup-ssh-via-ssm.sh
+++ b/bin/setup-ssh-via-ssm.sh
@@ -2,12 +2,22 @@
 
 #
 # This script uploads your public SSH key ('id_ed25519' by default)
-# to a home directory ('ec2-user' by default) on an EC2 instance.
+# to the home directories of 'ec2-user' and 'ssm-user'. While both
+# users are configured, it's recommended to use 'ec2-user' for SSH.
 # Written by Bruno Grande.
 #
-# Usage:    bash setup-ssh-via-ssm.sh INSTANCE_ID
+# Script usage:
 #
-# Example:  bash setup-ssh-via-ssm.sh i-0d3ff331a7b7a7e8b
+#   bash setup-ssh-via-ssm.sh INSTANCE_ID [PUBLIC_SSH_KEY]
+#
+# Example commands:
+#
+#   # Generic usage:
+#   bash setup-ssh-via-ssm.sh i-0d3ff331a7b7a7e8b
+#
+#   # If you have another SSH key that you want to use,
+#   # which should match your SSH config file (see below):
+#   bash setup-ssh-via-ssm.sh i-0d3ff331a7b7a7e8b ~/.ssh/id_rsa.pub
 #
 #
 # This script assumes that:
@@ -43,7 +53,7 @@
 
 # Command-line arguments and optional environment variables
 INSTANCE_ID="${1}"
-SSH_KEY_PUB="${SSH_KEY_PUB:-$HOME/.ssh/id_ed25519.pub}"
+SSH_KEY_PUB="${2:-$HOME/.ssh/id_ed25519.pub}"
 TARGET_USER="${TARGET_USER:-ec2-user}"
 
 # Assemble commands for setting up SSH keys for $TARGET_USER
@@ -52,6 +62,8 @@ COMMANDS=$(cat <<- END
   cd
   mkdir -p .ssh;
   echo $(<$SSH_KEY_PUB) > .ssh/authorized_keys;
+  sudo chmod 700 .ssh;
+  sudo chmod 600 .ssh/authorized_keys;
   sudo cp -r .ssh ${TARGET_HOMEDIR}/;
   sudo chmod 700 ${TARGET_HOMEDIR}/.ssh;
   sudo chmod 600 ${TARGET_HOMEDIR}/.ssh/authorized_keys;

--- a/bin/setup-ssh-via-ssm.sh
+++ b/bin/setup-ssh-via-ssm.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+#
+# This script uploads your public SSH key ('id_ed25519' by default)
+# to a home directory ('ec2-user' by default) on an EC2 instance.
+# Written by Bruno Grande.
+#
+# Usage:    bash setup-ssh-via-ssm.sh INSTANCE_ID
+#
+# Example:  bash setup-ssh-via-ssm.sh i-0d3ff331a7b7a7e8b
+#
+#
+# This script assumes that:
+#
+# - You have generated an ed25519 SSH key pair as per
+#   GitHub's best practices. Otherwise, you'll need to
+#   generate one using:
+#
+#     ssh-keygen -t ed25519 -C "your_email@example.com"
+#
+# - Your shell environment is configured with AWS credentials
+#   (AWS_PROFILE or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY).
+#   For example, if you have an AWS CLI profile based on the
+#   Service Catalog docs, you will first need to run this:
+#
+#     export AWS_PROFILE=service-catalog
+#
+#   Tip: If you only use the AWS CLI for the Service Catalog,
+#   consider making the config profile the default as follows:
+#
+#     [default]
+#     region=us-east-1
+#     credential_process = ...
+#
+# - Your SSH configuration file includes the following snippet
+#   (update the value for 'IdentityFile' as appropriate):
+#
+#     Host i-* mi-*
+#         ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
+#         IdentityFile ~/.ssh/id_ed25519
+#         User ec2-user
+#
+
+# Command-line arguments and optional environment variables
+INSTANCE_ID="${1}"
+SSH_KEY_PUB="${SSH_KEY_PUB:-$HOME/.ssh/id_ed25519.pub}"
+TARGET_USER="${TARGET_USER:-ec2-user}"
+
+# Assemble commands for setting up SSH keys for $TARGET_USER
+COMMANDS=$(cat <<- END
+  cd
+  mkdir -p .ssh;
+  echo $(<$SSH_KEY_PUB) > .ssh/authorized_keys;
+  chmod 700 .ssh;
+  chmod 600 .ssh/authorized_keys;
+  sudo rsync -a --chown=${TARGET_USER}:${TARGET_USER} .ssh/ /home/${TARGET_USER}/.ssh/;
+END
+)
+
+# Run commands remotely on $INSTANCE_ID using SSM
+echo
+echo "Running the following shell script on ${INSTANCE_ID}..."
+echo "$COMMANDS"
+aws ssm start-session --target "$INSTANCE_ID" \
+        --document-name AWS-StartInteractiveCommand \
+        --parameters command="$COMMANDS"
+
+# Attempt to SSH into the instance
+echo
+echo "You should now be able to connect using 'ssh $INSTANCE_ID'."
+echo "You can just use the SSH command for this instance going forward."
+echo "Connecting now..."
+echo
+ssh $INSTANCE_ID

--- a/bin/setup-ssh-via-ssm.sh
+++ b/bin/setup-ssh-via-ssm.sh
@@ -47,13 +47,15 @@ SSH_KEY_PUB="${SSH_KEY_PUB:-$HOME/.ssh/id_ed25519.pub}"
 TARGET_USER="${TARGET_USER:-ec2-user}"
 
 # Assemble commands for setting up SSH keys for $TARGET_USER
+TARGET_HOMEDIR="/home/${TARGET_USER}"
 COMMANDS=$(cat <<- END
   cd
   mkdir -p .ssh;
   echo $(<$SSH_KEY_PUB) > .ssh/authorized_keys;
-  chmod 700 .ssh;
-  chmod 600 .ssh/authorized_keys;
-  sudo rsync -a --chown=${TARGET_USER}:${TARGET_USER} .ssh/ /home/${TARGET_USER}/.ssh/;
+  sudo cp -r .ssh ${TARGET_HOMEDIR}/;
+  sudo chmod 700 ${TARGET_HOMEDIR}/.ssh;
+  sudo chmod 600 ${TARGET_HOMEDIR}/.ssh/authorized_keys;
+  sudo chown -R ${TARGET_USER}:${TARGET_USER} ${TARGET_HOMEDIR}/.ssh;
 END
 )
 


### PR DESCRIPTION
I often find myself having to remotely access EC2 instances using SSM. I typically want to use SSH because I either want to copy files off of the EC2 instance using SCP or edit files using VS Code (with the SSH Remote extension). This requires me running through the same steps every time. In light of this, I decided to capture those commands in a shell script that can automate the setup and minimize mistakes.

Here's an example command and associated output:

```console
❯ bash setup-ssh-via-ssm.sh i-0421aea79957b510c

Running the following shell script on i-0421aea79957b510c...
  cd
  mkdir -p .ssh;
  echo [...] > .ssh/authorized_keys;
  sudo cp -r .ssh /home/ec2-user/;
  sudo chmod 700 /home/ec2-user/.ssh;
  sudo chmod 600 /home/ec2-user/.ssh/authorized_keys;
  sudo chown -R ec2-user:ec2-user /home/ec2-user/.ssh;

Starting session with SessionId: bruno.grande@sagebase.org-0d714049d8619edac


Exiting session with sessionId: bruno.grande@sagebase.org-0d714049d8619edac.


You should now be able to connect using 'ssh i-0421aea79957b510c'.
You can just use the SSH command for this instance going forward.
Connecting now...

Last login: Wed Aug 24 19:55:28 2022 from localhost

   __|  __|  __|
   _|  (   \__ \   Amazon Linux 2 (ECS Optimized)
 ____|\___|____/

For documentation, visit http://aws.amazon.com/documentation/ecs
17 package(s) needed for security, out of 43 available
Run "sudo yum update" to apply all updates.
[ec2-user@ip-172-22-0-82 ~]$ 
```