### PR TITLE
Deploy Lambda function to auto-delete orphaned EBS volumes

### DIFF
--- a/config/common/lambda-ebs-cleanup.yaml
+++ b/config/common/lambda-ebs-cleanup.yaml
@@ -1,0 +1,11 @@
+template:
+  type: http
+  url: "https://bootstrap-awss3cloudformationbucket-19qromfd235z9.s3.amazonaws.com/lambda-ebs-cleanup/master/lambda-ebs-cleanup.yaml"
+stack_name: "lambda-ebs-cleanup"
+
+parameters:
+  Schedule: "cron(0/15 * * * ? *)"
+  MinimumAge: "15m"
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}


### PR DESCRIPTION
A big shout-out to @jesusaurus for putting together this Lambda function! 

This PR will deploy this Lambda to all AWS accounts and will scan for orphaned EBS volumes every 15 minutes. I overrode the default interval of daily with every 15 minutes because these volumes can accumulate very fast. Given their size (up to 1 TB), it's worth being a little more diligent with cleaning things up. 