### PR TITLE
[WORKFLOWS-455] Harden separation in S3 access between Tower projects

### DIFF
--- a/templates/tower-project.yaml
+++ b/templates/tower-project.yaml
@@ -193,7 +193,7 @@ Resources:
         Statement:
           - Sid: GrantExternalS3Access
             Effect: Allow
-            Action: "*"
+            Action: "s3:*"
             Resource: "*"
             Condition:
               StringNotEquals:

--- a/templates/tower-project.yaml
+++ b/templates/tower-project.yaml
@@ -191,9 +191,13 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Sid: GrantExternalS3Access
+          - Sid: ConditionalAmazonS3ReadOnlyAccess
             Effect: Allow
-            Action: "s3:*"
+            Action:
+              - "s3:Get*"
+              - "s3:List*"
+              - "s3-object-lambda:Get*"
+              - "s3-object-lambda:List*"
             Resource: "*"
             Condition:
               StringNotEquals:

--- a/templates/tower-project.yaml
+++ b/templates/tower-project.yaml
@@ -125,8 +125,6 @@ Resources:
   TowerForgeBatchHeadJobRole:
     Type: AWS::IAM::Role
     Properties:
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -139,8 +137,6 @@ Resources:
   TowerForgeBatchWorkJobRole:
     Type: AWS::IAM::Role
     Properties:
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -187,6 +183,25 @@ Resources:
               - !GetAtt TowerForgeBatchExecutionRole.Arn
       Roles:
         - !Ref TowerForgeBatchHeadJobRole
+
+  TowerForgeExternalS3AccessPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: TowerForgeExternalS3AccessPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: GrantExternalS3Access
+            Effect: Allow
+            Action: "*"
+            Resource: "*"
+            Condition:
+              StringNotEquals:
+                s3:ResourceAccount:
+                  - !Sub "${AWS::AccountId}"
+      Roles:
+        - !Ref TowerForgeBatchHeadJobRole
+        - !Ref TowerForgeBatchWorkJobRole
 
   TowerForgeBatchExecutionRole:
     Type: AWS::IAM::Role
@@ -303,6 +318,18 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
+          - Sid: DenyCrossProjectAccess
+            Effect: Deny
+            Principal:
+              AWS: "*"
+            Action:
+              - "s3:*"
+            Condition:
+              ArnLike:
+                aws:PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/TowerForge-*"
+            Resource:
+              - !Sub "arn:aws:s3:::${TowerBucket}"
+              - !Sub "arn:aws:s3:::${TowerBucket}/*"
           - Sid: TowerForgeRoleS3Access
             Effect: Allow
             Principal:
@@ -411,6 +438,18 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
+          - Sid: DenyCrossProjectAccess
+            Effect: Deny
+            Principal:
+              AWS: "*"
+            Action:
+              - "s3:*"
+            Condition:
+              ArnLike:
+                aws:PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/TowerForge-*"
+            Resource:
+              - !Sub "arn:aws:s3:::${TowerScratch}"
+              - !Sub "arn:aws:s3:::${TowerScratch}/*"
           - Sid: TowerForgeRoleS3Access
             Effect: Allow
             Principal:


### PR DESCRIPTION
At the time of writing, access between Tower projects is impossible due to KMS encryption. This PR builds on that by restricting access using identify and resource policies. There were two "paths" that I wanted to block:

1. One of the IAM roles that are automatically created by Tower Forge is attached to the `AmazonS3ReadOnlyAccess` managed policy, which would grant it access to all S3 buckets within the account. In theory, these roles aren't used to access project buckets, but it's better to be safe than sorry. To address this, I added a specific block against all roles created by Forge (_i.e._ prefixed with `TowerForge-`). 
2. The head and worker job roles created by the `tower-project` template were also attached to the overly permissive `AmazonS3ReadOnlyAccess` policy. I dropped this in favor of an inline policy (`TowerForgeExternalS3AccessPolicy`) that grants these roles with access to all S3 resources outside of the account. This should complement the access they are granted by the bucket policies. 