### PR TITLE
[WORKFLOWS-461] Clean up Tower workspaces

### DIFF
--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -28,7 +28,6 @@ parameters:
   TowerUserWorkspace: 'false'
   TowerRootUsers:
     - bruno.grande@sagebase.org
-    - tess.thyer@sagebase.org
     - thomas.yu@sagebase.org
   TowerConfigFileName: 'tower.yaml'
 

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -28,7 +28,6 @@ parameters:
   TowerUserWorkspace: 'false'
   TowerRootUsers:
     - bruno.grande@sagebase.org
-    - tess.thyer@sagebase.org
     - thomas.yu@sagebase.org
   TowerConfigFileName: 'tower.yaml'
 

--- a/config/projects-ampad/example-ampad-project.yaml
+++ b/config/projects-ampad/example-ampad-project.yaml
@@ -6,12 +6,9 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/bruno.grande@sagebase.org
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/tess.thyer@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/tess.thyer@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/thomas.yu@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:

--- a/config/projects-ampad/example-ampad-project.yaml
+++ b/config/projects-ampad/example-ampad-project.yaml
@@ -8,7 +8,6 @@ parameters:
   S3ReadWriteAccessArns:
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/bruno.grande@sagebase.org
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/tess.thyer@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/thomas.yu@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:

--- a/config/projects-ampad/jared-hendrickson-project.yaml
+++ b/config/projects-ampad/jared-hendrickson-project.yaml
@@ -6,11 +6,8 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/william.poehlman@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/william.poehlman@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jared.hendrickson@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/jared.hendrickson@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/bruno.grande@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:

--- a/config/projects-ampad/strides-ampad-project.yaml
+++ b/config/projects-ampad/strides-ampad-project.yaml
@@ -6,9 +6,7 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/william.poehlman@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/william.poehlman@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/bruno.grande@sagebase.org
   S3ReadOnlyAccessArns:
     - arn:aws:iam::751556145034:role/jared-hendrickson-project-TowerForgeBatchHeadJobRo-1XYQQ76D6E75Z

--- a/config/projects-ampad/wei-an-chen-project.yaml
+++ b/config/projects-ampad/wei-an-chen-project.yaml
@@ -6,11 +6,8 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/william.poehlman@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/william.poehlman@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/wei-an.chen@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/wei-an.chen@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/bruno.grande@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:

--- a/config/projects-dev/example-dev-project.yaml
+++ b/config/projects-dev/example-dev-project.yaml
@@ -6,12 +6,9 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/bruno.grande@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
     - arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/thomas.yu@sagebase.org
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/tess.thyer@sagebase.org
     - arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/tess.thyer@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:

--- a/config/projects-dev/example-dev-project.yaml
+++ b/config/projects-dev/example-dev-project.yaml
@@ -9,7 +9,7 @@ parameters:
     - arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/bruno.grande@sagebase.org
     - arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/thomas.yu@sagebase.org
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/tess.thyer@sagebase.org
+    - arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/brad.macdonald@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-prod/amp-ad-project.yaml
+++ b/config/projects-prod/amp-ad-project.yaml
@@ -6,9 +6,7 @@ dependencies:
 
 parameters:
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/william.poehlman@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/william.poehlman@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/tess.thyer@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/tess.thyer@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:

--- a/config/projects-prod/amp-ad-project.yaml
+++ b/config/projects-prod/amp-ad-project.yaml
@@ -7,7 +7,6 @@ dependencies:
 parameters:
   S3ReadOnlyAccessArns:
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/william.poehlman@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/tess.thyer@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-prod/ctf-swnts-project.yaml
+++ b/config/projects-prod/ctf-swnts-project.yaml
@@ -14,22 +14,10 @@ stack_tags:
 parameters:
 
   S3ReadWriteAccessArns:
-    # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/sasha.scott@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
-
-    # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jineta.banerjee@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-
-  # (Optional) Step 5: Uncomment and update the following line(s) to grant additional users with read-only access
-  # S3ReadOnlyAccessArns:
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)

--- a/config/projects-prod/example-project.yaml
+++ b/config/projects-prod/example-project.yaml
@@ -15,17 +15,14 @@ parameters:
 
   S3ReadWriteAccessArns:
     # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
 
     # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
-    # - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/tess.thyer@sagebase.org
-    # - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/william.poehlman@sagebase.org
+    # - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/thomas.yu@sagebase.org
 
   # (Optional) Step 5: Uncomment and update the following line(s) to grant additional users with read-only access
   # S3ReadOnlyAccessArns:
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org
+  #   - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/brad.macdonald@sagebase.org
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)

--- a/config/projects-prod/genie-bpc-project.yaml
+++ b/config/projects-prod/genie-bpc-project.yaml
@@ -7,11 +7,8 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/xindi.guo@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/xindi.guo@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/thomas.yu@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/chelsea.nayan@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/chelsea.nayan@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:

--- a/config/projects-prod/htan-project.yaml
+++ b/config/projects-prod/htan-project.yaml
@@ -6,9 +6,7 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/adam.taylor@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/milen.nikolov@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/milen.nikolov@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/brad.macdonald@sagebase.org
   AllowSynapseIndexing: Enabled

--- a/config/projects-prod/imcore-project.yaml
+++ b/config/projects-prod/imcore-project.yaml
@@ -6,9 +6,7 @@ dependencies:
 
 parameters:
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/james.eddy@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/james.eddy@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:

--- a/config/projects-prod/jhu-biobank-nf-project.yaml
+++ b/config/projects-prod/jhu-biobank-nf-project.yaml
@@ -6,9 +6,7 @@ dependencies:
 
 parameters:
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jineta.banerjee@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
   AllowSynapseIndexing: Enabled
   AccountAdminArns:

--- a/config/projects-prod/mc2-mcmicro-project.yaml
+++ b/config/projects-prod/mc2-mcmicro-project.yaml
@@ -6,7 +6,6 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/adam.taylor@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org
     - arn:aws:iam::292075781285:user/sokolov
     - arn:aws:iam::292075781285:user/cy101

--- a/config/projects-prod/nf-ntap5-biobank-jineta.yaml
+++ b/config/projects-prod/nf-ntap5-biobank-jineta.yaml
@@ -1,4 +1,4 @@
-stack_name: nf-ntap5-biobank-jineta
+stack_name: nf-ntap5-biobank-jineta-project
 
 stack_tags:
   # (REQUIRED) Step 2: Update all four values below
@@ -9,19 +9,11 @@ stack_tags:
 
 parameters:
 
-  S3ReadWriteAccessArns:
-    # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jineta.banerjee@sagebase.org
-
-
-    # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org
-
-  # (Optional) Step 5: Uncomment and update the following line(s) to grant additional users with read-only access
-  # S3ReadOnlyAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/sasha.scott@sagebase.org
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org
+  S3ReadOnlyAccessArns:
+    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
+    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
+    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
+    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)

--- a/config/projects-prod/nfri-ctf-nf1-project.yaml
+++ b/config/projects-prod/nfri-ctf-nf1-project.yaml
@@ -9,22 +9,10 @@ stack_tags:
 parameters:
 
   S3ReadWriteAccessArns:
-    # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-
-    # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/sasha.scott@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jineta.banerjee@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-
-  # (Optional) Step 5: Uncomment and update the following line(s) to grant additional users with read-only access
-  # S3ReadOnlyAccessArns:
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org
 
   # (Optional) Step 6: Uncomment and update the following lines to change the S3 bucket lifecycle configuration,
   #                    which cannot be changed as long as 'AllowSynapseIndexing' is enabled (default)

--- a/config/projects-prod/ntap-add5-project.yaml
+++ b/config/projects-prod/ntap-add5-project.yaml
@@ -6,11 +6,8 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jineta.banerjee@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
   AccountAdminArns:

--- a/config/projects-prod/ntap-cnf-cell-project.yaml
+++ b/config/projects-prod/ntap-cnf-cell-project.yaml
@@ -9,20 +9,9 @@ stack_tags:
 parameters:
 
   S3ReadWriteAccessArns:
-    # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-
-    # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jineta.banerjee@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-
-  # (Optional) Step 5: Uncomment and update the following line(s) to grant additional users with read-only access
-  # S3ReadOnlyAccessArns:
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org
 
   # (Optional) Step 6: Uncomment and update the following lines to change the S3 bucket lifecycle configuration,
   #                    which cannot be changed as long as 'AllowSynapseIndexing' is enabled (default)

--- a/config/projects-prod/robert-allaway-project.yaml
+++ b/config/projects-prod/robert-allaway-project.yaml
@@ -13,21 +13,10 @@ stack_tags:
 
 parameters:
 
-  S3ReadWriteAccessArns:
-    # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org
+  S3ReadOnlyAccessArns:
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-
-    # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jineta.banerjee@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/sasha.scott@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
-
-  # (Optional) Step 5: Uncomment and update the following line(s) to grant additional users with read-only access
-  # S3ReadOnlyAccessArns:
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)

--- a/config/projects-prod/sophia-jobe-project.yaml
+++ b/config/projects-prod/sophia-jobe-project.yaml
@@ -13,20 +13,9 @@ stack_tags:
 
 parameters:
 
-  S3ReadWriteAccessArns:
-    # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/sophia.jobe@sagebase.org
+  S3ReadOnlyAccessArns:
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sophia.jobe@sagebase.org
-
-    # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
-    # - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/tess.thyer@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/william.poehlman@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/william.poehlman@sagebase.org
-
-  # (Optional) Step 5: Uncomment and update the following line(s) to grant additional users with read-only access
-  # S3ReadOnlyAccessArns:
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)

--- a/config/projects-prod/ucf-dod-nf2-project.yaml
+++ b/config/projects-prod/ucf-dod-nf2-project.yaml
@@ -8,23 +8,11 @@ stack_tags:
 
 parameters:
 
-  S3ReadWriteAccessArns:
-    # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org
+  S3ReadOnlyAccessArns:
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-
-    # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/sasha.scott@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jineta.banerjee@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-
-  # (Optional) Step 5: Uncomment and update the following line(s) to grant additional users with read-only access
-  # S3ReadOnlyAccessArns:
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org
 
   # (Optional) Step 6: Uncomment and update the following lines to change the S3 bucket lifecycle configuration,
   #                    which cannot be changed as long as 'AllowSynapseIndexing' is enabled (default)

--- a/config/projects-prod/verena-chung-project.yaml
+++ b/config/projects-prod/verena-chung-project.yaml
@@ -13,20 +13,9 @@ stack_tags:
 
 parameters:
 
-  S3ReadWriteAccessArns:
-    # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/verena.chung@sagebase.org
+  S3ReadOnlyAccessArns:
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/verena.chung@sagebase.org
-
-    # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
-    # - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/tess.thyer@sagebase.org
-    - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/william.poehlman@sagebase.org
     - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/william.poehlman@sagebase.org
-
-  # (Optional) Step 5: Uncomment and update the following line(s) to grant additional users with read-only access
-  # S3ReadOnlyAccessArns:
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/thomas.yu@sagebase.org
-  #   - arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)


### PR DESCRIPTION
In order to move forward on WORKFLOWS-461, I need to create some space for new compute environments in AWS Batch. This PR decommissions 4 Tower projects, which will free up 12 slots in AWS Batch. I also took the opportunity to remove the old sandbox roles (no longer available), delete extraneous comments, and remove mentions of Tess. 

Depends on #141 