### PR TITLE
[WORKFLOWS-481] Parametrize TowerViewer assumed-role ARN prefix

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
       - uses: pre-commit/action@v2.0.2
 
   deploy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.8
+    python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/config/projects-ampad/config.yaml
+++ b/config/projects-ampad/config.yaml
@@ -1,3 +1,4 @@
+tower_viewer_arn_prefix: arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer
 # Technically, this AWS account isn't set up through SSO since
 # it sits outside of our AWS Organization fo STRIDES billing
 sso_admin_role:

--- a/config/projects-ampad/example-ampad-project.yaml
+++ b/config/projects-ampad/example-ampad-project.yaml
@@ -6,9 +6,9 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/bruno.grande@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/thomas.yu@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-ampad/jared-hendrickson-project.yaml
+++ b/config/projects-ampad/jared-hendrickson-project.yaml
@@ -6,9 +6,9 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/william.poehlman@sagebase.org
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/jared.hendrickson@sagebase.org
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/bruno.grande@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/william.poehlman@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jared.hendrickson@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-ampad/strides-ampad-project.yaml
+++ b/config/projects-ampad/strides-ampad-project.yaml
@@ -6,8 +6,8 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/william.poehlman@sagebase.org
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/bruno.grande@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/william.poehlman@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
   S3ReadOnlyAccessArns:
     - arn:aws:iam::751556145034:role/jared-hendrickson-project-TowerForgeBatchHeadJobRo-1XYQQ76D6E75Z
     - arn:aws:iam::751556145034:role/jared-hendrickson-project-TowerForgeBatchWorkJobRo-1V2DBC9NYIPOB

--- a/config/projects-ampad/wei-an-chen-project.yaml
+++ b/config/projects-ampad/wei-an-chen-project.yaml
@@ -6,9 +6,9 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/william.poehlman@sagebase.org
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/wei-an.chen@sagebase.org
-    - arn:aws:sts::751556145034:assumed-role/strides-ampad-workflows-towerviewer/bruno.grande@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/william.poehlman@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/wei-an.chen@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-dev/config.yaml
+++ b/config/projects-dev/config.yaml
@@ -1,2 +1,3 @@
+tower_viewer_arn_prefix: arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2
 sso_admin_role:
   arn: arn:aws:iam::035458030717:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_580e9f32ac55c4e7

--- a/config/projects-dev/example-dev-project.yaml
+++ b/config/projects-dev/example-dev-project.yaml
@@ -6,10 +6,10 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/bruno.grande@sagebase.org
-    - arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/thomas.yu@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/brad.macdonald@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/brad.macdonald@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-prod/amp-ad-project.yaml
+++ b/config/projects-prod/amp-ad-project.yaml
@@ -6,7 +6,7 @@ dependencies:
 
 parameters:
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/william.poehlman@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/william.poehlman@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-prod/config.yaml
+++ b/config/projects-prod/config.yaml
@@ -1,2 +1,3 @@
+tower_viewer_arn_prefix: arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705
 sso_admin_role:
   arn: arn:aws:iam::728882028485:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_3a9d61d0884be260

--- a/config/projects-prod/ctf-swnts-project.yaml
+++ b/config/projects-prod/ctf-swnts-project.yaml
@@ -14,10 +14,10 @@ stack_tags:
 parameters:
 
   S3ReadWriteAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/sasha.scott@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jineta.banerjee@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)

--- a/config/projects-prod/example-project.yaml
+++ b/config/projects-prod/example-project.yaml
@@ -15,14 +15,14 @@ parameters:
 
   S3ReadWriteAccessArns:
     # (REQUIRED) Step 3: Replace the email below with your '@sagebase.org' address
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
 
     # (Optional) Step 4: Uncomment and update the following line(s) to grant additional users with read/write access
-    # - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/thomas.yu@sagebase.org
+    # - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
 
   # (Optional) Step 5: Uncomment and update the following line(s) to grant additional users with read-only access
   # S3ReadOnlyAccessArns:
-  #   - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/brad.macdonald@sagebase.org
+  #   - '{{stack_group_config.tower_viewer_arn_prefix}}/brad.macdonald@sagebase.org'
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)

--- a/config/projects-prod/genie-bpc-project.yaml
+++ b/config/projects-prod/genie-bpc-project.yaml
@@ -7,9 +7,9 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/xindi.guo@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/thomas.yu@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/chelsea.nayan@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/xindi.guo@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/chelsea.nayan@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-prod/htan-project.yaml
+++ b/config/projects-prod/htan-project.yaml
@@ -6,9 +6,9 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/milen.nikolov@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/brad.macdonald@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/adam.taylor@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/milen.nikolov@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/brad.macdonald@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-prod/imcore-project.yaml
+++ b/config/projects-prod/imcore-project.yaml
@@ -6,8 +6,8 @@ dependencies:
 
 parameters:
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/james.eddy@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/james.eddy@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-prod/jhu-biobank-nf-project.yaml
+++ b/config/projects-prod/jhu-biobank-nf-project.yaml
@@ -6,8 +6,8 @@ dependencies:
 
 parameters:
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jineta.banerjee@sagebase.org'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'

--- a/config/projects-prod/mc2-mcmicro-project.yaml
+++ b/config/projects-prod/mc2-mcmicro-project.yaml
@@ -6,7 +6,7 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/adam.taylor@sagebase.org'
     - arn:aws:iam::292075781285:user/sokolov
     - arn:aws:iam::292075781285:user/cy101
     - arn:aws:iam::292075781285:user/jmuhlich

--- a/config/projects-prod/nf-ntap5-biobank-jineta.yaml
+++ b/config/projects-prod/nf-ntap5-biobank-jineta.yaml
@@ -10,10 +10,10 @@ stack_tags:
 parameters:
 
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jineta.banerjee@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/sasha.scott@sagebase.org'
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)

--- a/config/projects-prod/nfri-ctf-nf1-project.yaml
+++ b/config/projects-prod/nfri-ctf-nf1-project.yaml
@@ -9,10 +9,10 @@ stack_tags:
 parameters:
 
   S3ReadWriteAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/sasha.scott@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jineta.banerjee@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
 
   # (Optional) Step 6: Uncomment and update the following lines to change the S3 bucket lifecycle configuration,
   #                    which cannot be changed as long as 'AllowSynapseIndexing' is enabled (default)

--- a/config/projects-prod/ntap-add5-project.yaml
+++ b/config/projects-prod/ntap-add5-project.yaml
@@ -6,10 +6,10 @@ dependencies:
 
 parameters:
   S3ReadWriteAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jineta.banerjee@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/sasha.scott@sagebase.org'
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'
     - !stack_output_external workflows-nextflow-ci-service-account::ServiceRoleArn

--- a/config/projects-prod/ntap-cnf-cell-project.yaml
+++ b/config/projects-prod/ntap-cnf-cell-project.yaml
@@ -9,9 +9,9 @@ stack_tags:
 parameters:
 
   S3ReadWriteAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jineta.banerjee@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
 
   # (Optional) Step 6: Uncomment and update the following lines to change the S3 bucket lifecycle configuration,
   #                    which cannot be changed as long as 'AllowSynapseIndexing' is enabled (default)

--- a/config/projects-prod/robert-allaway-project.yaml
+++ b/config/projects-prod/robert-allaway-project.yaml
@@ -14,9 +14,9 @@ stack_tags:
 parameters:
 
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jineta.banerjee@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/sasha.scott@sagebase.org'
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)

--- a/config/projects-prod/sophia-jobe-project.yaml
+++ b/config/projects-prod/sophia-jobe-project.yaml
@@ -14,8 +14,8 @@ stack_tags:
 parameters:
 
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sophia.jobe@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/william.poehlman@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/sophia.jobe@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/william.poehlman@sagebase.org'
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)

--- a/config/projects-prod/ucf-dod-nf2-project.yaml
+++ b/config/projects-prod/ucf-dod-nf2-project.yaml
@@ -9,10 +9,10 @@ stack_tags:
 parameters:
 
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/sasha.scott@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/jineta.banerjee@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/bruno.grande@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/robert.allaway@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/sasha.scott@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jineta.banerjee@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
 
   # (Optional) Step 6: Uncomment and update the following lines to change the S3 bucket lifecycle configuration,
   #                    which cannot be changed as long as 'AllowSynapseIndexing' is enabled (default)

--- a/config/projects-prod/verena-chung-project.yaml
+++ b/config/projects-prod/verena-chung-project.yaml
@@ -14,8 +14,8 @@ stack_tags:
 parameters:
 
   S3ReadOnlyAccessArns:
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/verena.chung@sagebase.org
-    - arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/william.poehlman@sagebase.org
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/verena.chung@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/william.poehlman@sagebase.org'
 
   # (Optional) Step 6: Uncomment the following line to disable the feature allowing Synapse to index files
   #                    in the long-term (archival) S3 bucket (by default, this feature is enabled)


### PR DESCRIPTION
A lot of files of being changed in this PR, but most of it was done with search and replace queries in VS Code (example below). It basically moves the common prefix for the TowerViewer assumed-role ARN to the Sceptre config. 

**Edit:** I'm not sure what's wrong with the pre-commit in the CI workflow, so I'll need to debug that too. 

- [ ] Debug pre-commit in CI workflow

```
Search:   arn:aws:sts::035458030717:assumed-role/AWSReservedSSO_TowerViewer_5919a1dd6875ede2/([\w@.]+)
Replace:  '{{stack_group_config.tower_viewer_arn_prefix}}/$1'
```