### PR TITLE
[IBCDPE-404] Remove unlisted participants in each workspace

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -8,7 +8,7 @@ import os
 import re
 import time
 from collections import defaultdict
-from typing import Dict, Iterator, List, Optional, Sequence, Tuple
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Set
 
 import boto3
 import yaml  # type: ignore
@@ -425,14 +425,14 @@ class TowerWorkspace:
         participants = self.tower.paged_request("GET", endpoint)
         return participants
 
-    def list_owner_participant_ids(self) -> List[int]:
+    def list_owner_participant_ids(self) -> Set[int]:
         """List the participant IDs of any workspace owners
 
         This will include the workspace creator.
         """
         participants = self.list_participants()
         owners = [part for part in participants if part["wspRole"] == "owner"]
-        owner_ids = [owner["participantId"] for owner in owners]
+        owner_ids = {owner["participantId"] for owner in owners}
         return owner_ids
 
     def populate(self) -> None:

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -410,7 +410,7 @@ class TowerWorkspace:
         self.tower.request("PUT", endpoint, json=data)
 
     def remove_participant(self, part_id: int) -> Dict:
-        """Remove a member from an organization team
+        """Remove a participant from a workspace
 
         Args:
             part_id (int): Participant ID for the user or team
@@ -419,17 +419,17 @@ class TowerWorkspace:
         response = self.tower.request("DELETE", endpoint)
         return response
 
-    def list_participants(self) -> Dict:
-        """Remove a member from an organization team
-
-        Args:
-            part_id (int): Participant ID for the user or team
-        """
+    def list_participants(self) -> Iterator:
+        """List the participants in a workspace"""
         endpoint = f"/orgs/{self.org.id}/workspaces/{self.id}/participants"
         participants = self.tower.paged_request("GET", endpoint)
         return participants
 
-    def get_owner_participant_ids(self) -> List[int]:
+    def list_owner_participant_ids(self) -> List[int]:
+        """List the participant IDs of any workspace owners
+
+        This will include the workspace creator.
+        """
         participants = self.list_participants()
         owners = [part for part in participants if part["wspRole"] == "owner"]
         owner_ids = [owner["participantId"] for owner in owners]
@@ -438,7 +438,7 @@ class TowerWorkspace:
     def populate(self) -> None:
         """Add maintainers and viewers to the organization and workspace"""
         if self.users:
-            owner_ids = self.get_owner_participant_ids()
+            owner_ids = self.list_owner_participant_ids()
             verified_ids = set(owner_ids)
             for user, _, role in self.users.list_users():
                 # Add expected participants

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -445,11 +445,11 @@ class TowerWorkspace:
                 part = self.add_participant(role, user=user)
                 part_id = part["participantId"]
                 verified_ids.add(part_id)
-                # Remove unexpected team members
-                for part in self.list_participants():
-                    part_id = part["participantId"]
-                    if part_id not in verified_ids:
-                        self.remove_participant(part_id)
+            # Remove unexpected team members
+            for part in self.list_participants():
+                part_id = part["participantId"]
+                if part_id not in verified_ids:
+                    self.remove_participant(part_id)
         if self.teams:
             for team_id, role in self.teams.items():
                 self.add_participant(role, team_id=team_id)


### PR DESCRIPTION
This PR addresses an issue that got introduced when we reverted from managing access using teams back to using users (c77aac2da7ac253a187b6461b022d4307fc18e9e). While the teams functionality removed any unexpected team members, this feature had not been implemented yet for the users functionality. This PR addresses this gap. 

In practice, this should ensure that any users that are removed from Tower project stacks will also be removed from the corresponding Tower workspace. 

Depends on #143 