### PR TITLE
[ORCA-105] Create `orca-dev-project` Tower project

### DIFF
--- a/config/projects-dev/orca-dev-project.yaml
+++ b/config/projects-dev/orca-dev-project.yaml
@@ -1,0 +1,24 @@
+template_path: tower-project.yaml
+stack_name: orca-dev-project
+dependencies:
+  - common/nextflow-forge-iam-policy.yaml
+  - common/nextflow-launch-iam-policy.yaml
+
+parameters:
+  S3ReadWriteAccessArns:
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/brad.macdonald@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/bruno.grande@sagebase.org'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/thomas.yu@sagebase.org'
+  AllowSynapseIndexing: Enabled
+  AccountAdminArns:
+    - '{{stack_group_config.sso_admin_role.arn}}'
+    - !stack_output_external workflows-nextflow-ci-service-account::ServiceRoleArn
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
+  TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
+  TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
+
+stack_tags:
+  Department: IBC
+  Project: Infrastructure
+  OwnerEmail: nextflow-admins@sagebase.org
+  CostCenter: NO PROGRAM / 000000


### PR DESCRIPTION
In response to a discussion in https://github.com/Sage-Bionetworks-Workflows/orca-recipes/pull/3, we might want to explore using the Tower-dev instance for testing purposes with Airflow. 