### PR TITLE
[WORKFLOWS-497] Only return non-duplicated emails

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -207,18 +207,18 @@ class Projects:
         role_arn_regex = re.compile(
             r".*/(?P<session_name>[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,})"
         )
-        emails = list()
+        emails = set()
         for arn in arns:
             match = role_arn_regex.fullmatch(arn)
             if match:
                 email = match.group("session_name")
-                emails.append(email)
+                emails.add(email)
             else:
                 print(
                     f"Listed ARN ({arn}) doesn't follow expected format: "
                     "'arn:aws:sts::<account_id>:<role_name>:<email>'"
                 )
-        return emails
+        return list(emails)
 
     def extract_users(self) -> Dict[str, Users]:
         """Extract users from a series of config files


### PR DESCRIPTION
By specifying more than one ARN that has a specific user's email, you run into the possibility of having duplicated emails.  This removes duplicates.

Full disclosure - I haven't tested this locally.   It could be interesting to have a full set of instructions to test these scripts within the dev environment.  

For instance
1. Create dev stack in `config/projects-dev`
2. pipenv run ...
3. success?