### PR TITLE
Ensure that MC2 external users are added to Tower

### DIFF
--- a/config/projects-prod/mc2-mcmicro-project.yaml
+++ b/config/projects-prod/mc2-mcmicro-project.yaml
@@ -10,6 +10,12 @@ parameters:
     - arn:aws:iam::292075781285:user/sokolov
     - arn:aws:iam::292075781285:user/cy101
     - arn:aws:iam::292075781285:user/jmuhlich
+    # The following roles don't exist since the users are not Sage employees.
+    # However, this will ensure that they are added to the Tower workspace
+    # until we find a permanent solution for listing external users.
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/artem.sokolov@gmail.com'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/clarenceyapp111@gmail.com'
+    - '{{stack_group_config.tower_viewer_arn_prefix}}/jmuhlich@gmail.com'
   AllowSynapseIndexing: Enabled
   AccountAdminArns:
     - '{{stack_group_config.sso_admin_role.arn}}'


### PR DESCRIPTION
I'm using existing functionality in the `configure-tower` script to ensure that the external users for the MC2 project are added to the Tower workspace. This is the quickest way of achieving that (other than manually adding them again). The better approach would be to add a new section in the YAML file (_e.g._ using `scepter_user_data`), but since we expect these stacks to be revamped soon to support custom AWS Batch compute environments, I opted against that for expediency.

This is a low-risk PR and one of our users is blocked, so I'm going to merge immediately, but I'm still open to feedback. 