### PR TITLE
[IT-2364] Improve allocation strategy and instance types

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -632,9 +632,7 @@ class TowerWorkspace:
         # Including multiple families will grant CEs with access to a greater pool
         # of instances when provisioning spot instances.
         instance_types = list(NONGPU_EC2_INSTANCE_TYPES)
-        # TODO: Consider always including GPU-enabled instance for simplicity
-        #       Is there a drawback to always setting gpuEnabled=True?
-        # instance_types.extend(GPU_EC2_INSTANCE_TYPES)
+        instance_types.extend(GPU_EC2_INSTANCE_TYPES)
 
         # This is modeled after a request made in the Tower web client
         data = {
@@ -674,7 +672,7 @@ class TowerWorkspace:
                         "ec2KeyPair": None,
                         "ecsConfig": None,
                         "efsCreate": False,
-                        "gpuEnabled": False,
+                        "gpuEnabled": True,
                         "imageId": None,
                         "instanceTypes": instance_types,
                         "maxCpus": 1000,

--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -632,7 +632,8 @@ class TowerWorkspace:
         # Including multiple families will grant CEs with access to a greater pool
         # of instances when provisioning spot instances.
         instance_types = list(NONGPU_EC2_INSTANCE_TYPES)
-        instance_types.extend(GPU_EC2_INSTANCE_TYPES)
+        # Leaving this out based on Sage-Bionetworks-Workflows/nextflow-infra#161
+        # instance_types.extend(GPU_EC2_INSTANCE_TYPES)
 
         # This is modeled after a request made in the Tower web client
         data = {
@@ -672,7 +673,7 @@ class TowerWorkspace:
                         "ec2KeyPair": None,
                         "ecsConfig": None,
                         "efsCreate": False,
-                        "gpuEnabled": True,
+                        "gpuEnabled": False,
                         "imageId": None,
                         "instanceTypes": instance_types,
                         "maxCpus": 1000,


### PR DESCRIPTION
@adamjtaylor needs GPUs to be enabled for the `mc2-mcmicro-project` workspace. I'm wondering if we can enable GPUs across all compute environments to avoid having to support a distinction between GPU-enabled and GPU-disabled workspaces. This is feasible because we expect AWS Batch to select the cheapest instance types where possible, so if a job doesn't ask for GPUs, then there should be no risk for a more expensive instance type (_e.g._ one that is GPU-enabled) to be selected. I've [asked](https://nextflow.slack.com/archives/C02T97HAV5M/p1676661020433299) if enabling GPUs in the Tower compute environment has any drawbacks. 

I'm also taking this opportunity to start using `SPOT_CAPACITY_OPTIMIZED` for our spot compute environments. This is a smarter allocation strategy where instance types are selected based on how likely they will be interrupted. This will hopefully result in fewer spot interruptions, especially with the greater list of instance types that is included in this PR. 

**Edit:** Based on a response that I got on [Slack](https://nextflow.slack.com/archives/C02T97HAV5M/p1676662072898669), we might not want to do this. I don't think the scenario described below would happen very often because all workspaces but one are expected to submit non-GPU jobs. That said, I wonder if the risk is worth the little amount of time it takes to clone a CE and enable GPUs. 

> Yes. You can end up submitting non-GPU jobs to GPU nodes and cause them to run for longer than necessary.
> Say if they get started by a job that needs a GPU, then a job comes along that only needs CPU. Batch can scheduled onto the GPU node. The first finishes but the second doesn't.
> $$$ down the toilet