### PR TITLE
[WORKFLOWS-517] Switch to `BEST_FIT` for smaller instances

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -15,7 +15,7 @@ import yaml  # type: ignore
 from sagetasks.nextflowtower.client import TowerClient
 
 # Increment this version when updating compute environments
-CE_VERSION = "v9"
+CE_VERSION = "v10"
 
 REGION = "us-east-1"
 ORG_NAME = "Sage Bionetworks"
@@ -631,8 +631,9 @@ class TowerWorkspace:
             label_id = self.create_resource_label(key, value)
             label_ids.append(label_id)
 
-        # Determine allocation strategy
-        alloc_strategy = "BEST_FIT_PROGRESSIVE"
+        # 'BEST_FIT' ensures that smaller instances are used, which limits the number
+        # of jobs per instance. It also ensures that the head job is isolated.
+        alloc_strategy = "BEST_FIT"
         if model == "SPOT":
             # With this strategy, "instance types that are less likely
             # to be interrupted are preferred" according to the AWS docs


### PR DESCRIPTION
Currently, the AWS Batch allocation strategy (`BEST_FIT_PROGRESSIVE`) has a tendency to provision larger instances because they're cheaper per vCPU. However, this is problematic because you end up with a head job (16 vCPUs) sharing resources with worker jobs on a larger instance (32 vCPUs). If these jobs are well-behaved, they shouldn't use more than the allocated amount of memory or CPUs, but they do cause big spikes in network traffic when staging or uploading files. In turn, this causes the network bandwidth to become saturated, preventing the head job from being able to communicate updates to Tower. 

This PR changes the allocation strategy to `BEST_FIT`, which will prefer smaller instance types. Hence, when the head job is scheduled, an instance type that only fits it (16 vCPUs) will be provisioned, preventing worker jobs from being scheduled on that instance since it will be "full". 