### PR TITLE
[IBCSPRT-159] Add shorter data expiration lifecycle rules

### DIFF
--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -434,7 +434,7 @@ Resources:
             Status: !Ref EnableScratchDataExpiration
             ExpirationInDays: 30
             Prefix: work/
-          {%- set default_scratch_data_expirations = [3, 5, 7, 10, 20, 30, 60, 90] %}
+          {%- set default_scratch_data_expirations = [1, 3, 5, 7, 10, 20, 30, 60, 90] %}
           {%- set scratch_data_expirations = sceptre_user_data.scratch_data_expirations | default( default_scratch_data_expirations ) %}
           {%- for num in scratch_data_expirations %}
           - Id: DataExpirationFor{{ num }}DaysDirectory

--- a/templates/tower-project.j2
+++ b/templates/tower-project.j2
@@ -434,7 +434,7 @@ Resources:
             Status: !Ref EnableScratchDataExpiration
             ExpirationInDays: 30
             Prefix: work/
-          {%- set default_scratch_data_expirations = [10, 20, 30, 60, 90] %}
+          {%- set default_scratch_data_expirations = [3, 5, 7, 10, 20, 30, 60, 90] %}
           {%- set scratch_data_expirations = sceptre_user_data.scratch_data_expirations | default( default_scratch_data_expirations ) %}
           {%- for num in scratch_data_expirations %}
           - Id: DataExpirationFor{{ num }}DaysDirectory


### PR DESCRIPTION
Some projects stage large files that don't need to remain in the scratch bucket for long. This PR introduces shorter data expiration lifecycle rules as a short-term solution until Nextflow improves their file management and/or fix the `cleanup` functionality. 