### PR TITLE
[ORCA-171] Create container registry credentials for Wave service

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,12 +117,18 @@ The Nextflow Tower credentials (_i.e._ access tokens) were created manually usin
 
 ### AWS Secrets
 
-The following secrets were manually created in AWS Secrets Manager. They are used in some [Sceptre configurations](#configuration) and are retrieved using a [Sceptre resolver](https://github.com/iAnomaly/sceptre-resolver-aws-secrets-manager). We also create secrets during deployment and store them in Secrets Manager ([example](https://github.com/Sage-Bionetworks-Workflows/aws-workflows-nextflow-infra/blob/db37741e53fa5276b33b24d1af247d8d29bc0e56/templates/nextflow-tower-secret.yaml#L14-L34)), but these aren't listed here.
+The following secrets were manually created in AWS Secrets Manager. They are used in some [Sceptre configurations](#configuration) and are retrieved using a [Sceptre resolver](https://github.com/iAnomaly/sceptre-resolver-aws-secrets-manager). We also create secrets during deployment and store them in Secrets Manager ([example](https://github.com/Sage-Bionetworks-Workflows/aws-workflows-nextflow-infra/blob/db37741e53fa5276b33b24d1af247d8d29bc0e56/templates/nextflow-tower-secret.yaml#L14-L34)), but these aren't listed here. These are encrypted using the `workflows-infra` KMS key.
 
 - `nextflow/license`: The paid license key for Nextflow Tower
 - `nextflow/google_oauth_app`: The Google OAuth client credentials
 - `nextflow/github_service_acct`: The GitHub service account credentials
 - `nextflow/synapse_oauth_client`: The Synapse OAuth client ID and secret
+
+The following secrets were created in all AWS accounts (including `strides-ampad`). Note that personal access tokens were used as password where possible (see notes in LastPass). Each of these secrets were created with two key-value pairs (`username` and `password`). Another service account (`nextflow/ecr_service_acct`) is created using CloudFormation (see `wave-ecr-user` stack).
+
+- `nextflow/dockerhub_service_acct`: The Docker Hub service account credentials for the Wave service
+- `nextflow/ghcr_service_acct`: The GHCR service account credentials for the Wave service
+- `nextflow/quayio_service_acct`: The Quay.io service account credentials for the Wave service
 
 ## Additional Notes
 

--- a/config/infra-ampad/wave-ecr-user.yaml
+++ b/config/infra-ampad/wave-ecr-user.yaml
@@ -1,0 +1,9 @@
+template:
+  path: wave-ecr-user.yaml
+stack_name: wave-ecr-user
+
+dependencies:
+  - infra-ampad/workflows-kms-key.yaml
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/config/infra-ampad/workflows-kms-key.yaml
+++ b/config/infra-ampad/workflows-kms-key.yaml
@@ -1,0 +1,11 @@
+template_path: workflows-kms-key.yaml
+stack_name: workflows-infra-kms-key
+
+parameters:
+  TemplateRootUrl: 'https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com'
+  AccountAdminArns:
+    - {{stack_group_config.sso_admin_role.arn}}
+    - !stack_output_external workflows-nextflow-ci-service-account::ServiceRoleArn
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/config/infra-dev/wave-ecr-user.yaml
+++ b/config/infra-dev/wave-ecr-user.yaml
@@ -1,0 +1,9 @@
+template:
+  path: wave-ecr-user.yaml
+stack_name: wave-ecr-user
+
+dependencies:
+  - infra-dev/workflows-kms-key.yaml
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/config/infra-prod/wave-ecr-user.yaml
+++ b/config/infra-prod/wave-ecr-user.yaml
@@ -1,0 +1,9 @@
+template:
+  path: wave-ecr-user.yaml
+stack_name: wave-ecr-user
+
+dependencies:
+  - infra-prod/workflows-kms-key.yaml
+
+stack_tags:
+  {{stack_group_config.default_stack_tags}}

--- a/templates/wave-ecr-user.yaml
+++ b/templates/wave-ecr-user.yaml
@@ -1,0 +1,83 @@
+Description: Policy and IAM user for Wave service to access ECR
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  KmsKeyAlias:
+    Description: Optional. KMS key alias used to encrypt secrets stored in Secrets Manager.
+    Type: String
+    Default: 'alias/workflows-infra'
+
+Resources:
+  WaveEcrPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Sid: EcrRepositoryActions
+          Effect: Allow
+          Action:
+          - ecr:UntagResource
+          - ecr:GetDownloadUrlForLayer
+          - ecr:CompleteLayerUpload
+          - ecr:DescribeImages
+          - ecr:TagResource
+          - ecr:DescribeRepositories
+          - ecr:ListTagsForResource
+          - ecr:UploadLayerPart
+          - ecr:ListImages
+          - ecr:InitiateLayerUpload
+          - ecr:PutImage
+          Resource: !Sub "arn:aws:ecr:*:${AWS::AccountId}:repository/*"
+        - Sid: EcrGeneralActions
+          Effect: Allow
+          Action:
+          - ecr:CreateRepository
+          - ecr:DescribeRegistry
+          - ecr:GetAuthorizationToken
+          Resource: "*"
+
+  WaveServiceUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      ManagedPolicyArns:
+        - !Ref WaveEcrPolicy
+
+  WaveServiceUserAccessKey:
+    Type: 'AWS::IAM::AccessKey'
+    Properties:
+      UserName: !Ref WaveServiceUser
+
+  WaveServiceUserAccessKeySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: "nextflow/ecr_service_acct"
+      Description: !Sub "The ECR service account credentials for the Wave service (${WaveServiceUser} IAM user)"
+      SecretString: !Sub >-
+        {
+          "username": "${WaveServiceUserAccessKey}",
+          "password": "${WaveServiceUserAccessKey.SecretAccessKey}"
+        }
+      KmsKeyId: !Ref KmsKeyAlias
+
+Outputs:
+  WaveEcrPolicyArn:
+    Value: !Ref WaveEcrPolicy
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-WaveEcrPolicyArn'
+  WaveServiceUser:
+    Value: !Ref WaveServiceUser
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-WaveServiceUser'
+  WaveServiceUserArn:
+    Value: !GetAtt WaveServiceUser.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-WaveServiceUserArn'
+  WaveServiceUserAccessKeySecret:
+    Value: !Sub "${AWS::StackName}-TowerProjectConfiguration"
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-WaveServiceUserAccessKeySecret"
+  WaveServiceUserAccessKeySecretArn:
+    Value: !Ref WaveServiceUserAccessKeySecret
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-WaveServiceUserAccessKeySecretArn"


### PR DESCRIPTION
In preparation of using Wave, we need to authenticate all requests to container registries. I identified the 4 most commonly used registries: Docker Hub, Quay.io, GHCR, and ECR. The first three have their credentials stored in LastPass, and I manually ported them over to Secrets Manager (documented in `CONTRIBUTING.md`). The ECR credentials are account-specific, so I authored a CloudFormation stack that creates an IAM user and grants it a minimal set of ECR permissions. I haven't tested whether this works with Wave yet. 

It hurts having stacks that are so similar in the various `infra-*` subfolders, but I don't see any way around it because each account has its own administrator role that needs access to the `workflows-infra` KMS key. 

**Edit:** I intentionally did not update the Tower configuration script to use these credentials since that should be tackled in a separate PR. 