### PR TITLE
Update sceptre template_path

### DIFF
--- a/bin/configure-tower-projects.py
+++ b/bin/configure-tower-projects.py
@@ -197,8 +197,8 @@ class Projects:
         has_stack_name = "stack_name" in config
         is_valid = (
             has_stack_name
-            and "template_path" in config
-            and config["template_path"] == "tower-project.j2"
+            and "template" in config
+            and config["template"]["path"] == "tower-project.j2"
             and "parameters" in config
             and (
                 "S3ReadWriteAccessArns" in config["parameters"]

--- a/config/common/budget-compute.yaml
+++ b/config/common/budget-compute.yaml
@@ -1,4 +1,5 @@
-template_path: budget.yaml
+template:
+  path: budget.yaml
 stack_name: budget-compute
 
 parameters:

--- a/config/common/budget-other.yaml
+++ b/config/common/budget-other.yaml
@@ -1,4 +1,5 @@
-template_path: budget.yaml
+template:
+  path: budget.yaml
 stack_name: budget-other
 
 parameters:

--- a/config/common/budget-security.yaml
+++ b/config/common/budget-security.yaml
@@ -1,4 +1,5 @@
-template_path: budget.yaml
+template:
+  path: budget.yaml
 stack_name: budget-security
 
 parameters:

--- a/config/common/budget-storage.yaml
+++ b/config/common/budget-storage.yaml
@@ -1,4 +1,5 @@
-template_path: budget.yaml
+template:
+  path: budget.yaml
 stack_name: budget-storage
 
 parameters:

--- a/config/common/nextflow-forge-iam-policy.yaml
+++ b/config/common/nextflow-forge-iam-policy.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-forge-iam-policy.yaml
+template:
+  path: nextflow-forge-iam-policy.yaml
 stack_name: nextflow-forge-iam-policy
 
 stack_tags:

--- a/config/common/nextflow-launch-iam-policy.yaml
+++ b/config/common/nextflow-launch-iam-policy.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-launch-iam-policy.yaml
+template:
+  path: nextflow-launch-iam-policy.yaml
 stack_name: nextflow-launch-iam-policy
 
 stack_tags:

--- a/config/infra-ampad/workflows-kms-key.yaml
+++ b/config/infra-ampad/workflows-kms-key.yaml
@@ -1,4 +1,5 @@
-template_path: workflows-kms-key.yaml
+template:
+  path: workflows-kms-key.yaml
 stack_name: workflows-infra-kms-key
 
 parameters:

--- a/config/infra-dev/igenomes-bucket.yaml
+++ b/config/infra-dev/igenomes-bucket.yaml
@@ -1,4 +1,5 @@
-template_path: public-bucket.yaml
+template:
+  path: public-bucket.yaml
 stack_name: igenomes-bucket
 
 parameters:

--- a/config/infra-dev/nextflow-aurora-mysql.yaml
+++ b/config/infra-dev/nextflow-aurora-mysql.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-aurora-mysql.yaml
+template:
+  path: nextflow-aurora-mysql.yaml
 stack_name: nextflow-aurora-mysql
 dependencies:
   - infra-dev/nextflow-vpc.yaml

--- a/config/infra-dev/nextflow-ecs-cluster.yaml
+++ b/config/infra-dev/nextflow-ecs-cluster.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-ecs-cluster.yaml
+template:
+  path: nextflow-ecs-cluster.yaml
 stack_name: nextflow-ecs-cluster
 dependencies:
   - infra-dev/nextflow-vpc.yaml

--- a/config/infra-dev/nextflow-ecs-security-group.yaml
+++ b/config/infra-dev/nextflow-ecs-security-group.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-ecs-security-group.yaml
+template:
+  path: nextflow-ecs-security-group.yaml
 stack_name: nextflow-ecs-security-group
 dependencies:
   - infra-dev/nextflow-vpc.yaml

--- a/config/infra-dev/nextflow-ecs-service.yaml
+++ b/config/infra-dev/nextflow-ecs-service.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-ecs-service.yaml
+template:
+  path: nextflow-ecs-service.yaml
 stack_name: nextflow-ecs-service
 dependencies:
   - infra-dev/nextflow-ecs-cluster.yaml

--- a/config/infra-dev/nextflow-ecs-task-definition.yaml
+++ b/config/infra-dev/nextflow-ecs-task-definition.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-ecs-task-definition.j2
+template:
+  path: nextflow-ecs-task-definition.j2
 stack_name: nextflow-ecs-task-definition
 dependencies:
   - infra-dev/nextflow-aurora-mysql.yaml

--- a/config/infra-dev/nextflow-efs-file-system.yaml
+++ b/config/infra-dev/nextflow-efs-file-system.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-efs-file-system.yaml
+template:
+  path: nextflow-efs-file-system.yaml
 stack_name: nextflow-efs-file-system
 dependencies:
   - infra-dev/nextflow-vpc.yaml

--- a/config/infra-dev/nextflow-r53-alias-record.yaml
+++ b/config/infra-dev/nextflow-r53-alias-record.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-r53-alias-record.yaml
+template:
+  path: nextflow-r53-alias-record.yaml
 stack_name: nextflow-r53-alias-record
 dependencies:
   - infra-dev/nextflow-r53-hostedzone.yaml

--- a/config/infra-dev/nextflow-tower-config-bucket.yaml
+++ b/config/infra-dev/nextflow-tower-config-bucket.yaml
@@ -1,5 +1,6 @@
 # {% set stack_name = "nextflow-tower-config-dev" %}
-template_path: nextflow-tower-config-bucket.yaml
+template:
+  path: nextflow-tower-config-bucket.yaml
 stack_name: {{ stack_name }}
 
 parameters:

--- a/config/infra-dev/nextflow-tower-secret.yaml
+++ b/config/infra-dev/nextflow-tower-secret.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-tower-secret.yaml
+template:
+  path: nextflow-tower-secret.yaml
 stack_name: nextflow-tower-secret
 dependencies:
   - infra-dev/workflows-kms-key.yaml

--- a/config/infra-dev/smtp-credentials.yaml
+++ b/config/infra-dev/smtp-credentials.yaml
@@ -1,4 +1,5 @@
-template_path: smtp-credentials.yaml
+template:
+  path: smtp-credentials.yaml
 stack_name: smtp-credentials
 
 parameters:

--- a/config/infra-dev/workflows-kms-key.yaml
+++ b/config/infra-dev/workflows-kms-key.yaml
@@ -1,4 +1,5 @@
-template_path: workflows-kms-key.yaml
+template:
+  path: workflows-kms-key.yaml
 stack_name: workflows-infra-kms-key
 
 parameters:

--- a/config/infra-prod/igenomes-bucket.yaml
+++ b/config/infra-prod/igenomes-bucket.yaml
@@ -1,4 +1,5 @@
-template_path: public-bucket.yaml
+template:
+  path: public-bucket.yaml
 stack_name: igenomes-bucket
 
 parameters:

--- a/config/infra-prod/nextflow-aurora-mysql.yaml
+++ b/config/infra-prod/nextflow-aurora-mysql.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-aurora-mysql.yaml
+template:
+  path: nextflow-aurora-mysql.yaml
 stack_name: nextflow-aurora-mysql
 dependencies:
   - infra-prod/nextflow-vpc.yaml

--- a/config/infra-prod/nextflow-ecs-cluster.yaml
+++ b/config/infra-prod/nextflow-ecs-cluster.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-ecs-cluster.yaml
+template:
+  path: nextflow-ecs-cluster.yaml
 stack_name: nextflow-ecs-cluster
 dependencies:
   - infra-prod/nextflow-vpc.yaml

--- a/config/infra-prod/nextflow-ecs-security-group.yaml
+++ b/config/infra-prod/nextflow-ecs-security-group.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-ecs-security-group.yaml
+template:
+  path: nextflow-ecs-security-group.yaml
 stack_name: nextflow-ecs-security-group
 dependencies:
   - infra-prod/nextflow-vpc.yaml

--- a/config/infra-prod/nextflow-ecs-service.yaml
+++ b/config/infra-prod/nextflow-ecs-service.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-ecs-service.yaml
+template:
+  path: nextflow-ecs-service.yaml
 stack_name: nextflow-ecs-service
 dependencies:
   - infra-prod/nextflow-ecs-cluster.yaml

--- a/config/infra-prod/nextflow-ecs-task-definition.yaml
+++ b/config/infra-prod/nextflow-ecs-task-definition.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-ecs-task-definition.j2
+template:
+  path: nextflow-ecs-task-definition.j2
 stack_name: nextflow-ecs-task-definition
 dependencies:
   - infra-prod/nextflow-aurora-mysql.yaml

--- a/config/infra-prod/nextflow-efs-file-system.yaml
+++ b/config/infra-prod/nextflow-efs-file-system.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-efs-file-system.yaml
+template:
+  path: nextflow-efs-file-system.yaml
 stack_name: nextflow-efs-file-system
 dependencies:
   - infra-prod/nextflow-vpc.yaml

--- a/config/infra-prod/nextflow-r53-alias-record.yaml
+++ b/config/infra-prod/nextflow-r53-alias-record.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-r53-alias-record.yaml
+template:
+  path: nextflow-r53-alias-record.yaml
 stack_name: nextflow-r53-alias-record
 dependencies:
   - infra-prod/nextflow-r53-hostedzone.yaml

--- a/config/infra-prod/nextflow-tower-config-bucket.yaml
+++ b/config/infra-prod/nextflow-tower-config-bucket.yaml
@@ -1,5 +1,6 @@
 # {% set stack_name = "nextflow-tower-config" %}
-template_path: nextflow-tower-config-bucket.yaml
+template:
+  path: nextflow-tower-config-bucket.yaml
 stack_name: {{ stack_name }}
 
 parameters:

--- a/config/infra-prod/nextflow-tower-secret.yaml
+++ b/config/infra-prod/nextflow-tower-secret.yaml
@@ -1,4 +1,5 @@
-template_path: nextflow-tower-secret.yaml
+template:
+  path: nextflow-tower-secret.yaml
 stack_name: nextflow-tower-secret
 dependencies:
   - infra-prod/workflows-kms-key.yaml

--- a/config/infra-prod/smtp-credentials.yaml
+++ b/config/infra-prod/smtp-credentials.yaml
@@ -1,4 +1,5 @@
-template_path: smtp-credentials.yaml
+template:
+  path: smtp-credentials.yaml
 stack_name: smtp-credentials
 
 parameters:

--- a/config/infra-prod/workflows-kms-key.yaml
+++ b/config/infra-prod/workflows-kms-key.yaml
@@ -1,4 +1,5 @@
-template_path: workflows-kms-key.yaml
+template:
+  path: workflows-kms-key.yaml
 stack_name: workflows-infra-kms-key
 
 parameters:

--- a/config/projects-ampad/agora-project.yaml
+++ b/config/projects-ampad/agora-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: agora-project
 
 stack_tags:

--- a/config/projects-ampad/example-ampad-project.yaml
+++ b/config/projects-ampad/example-ampad-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: example-ampad-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-ampad/jared-hendrickson-project.yaml
+++ b/config/projects-ampad/jared-hendrickson-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: jared-hendrickson-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-ampad/strides-ampad-project.yaml
+++ b/config/projects-ampad/strides-ampad-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: strides-ampad-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-ampad/wei-an-chen-project.yaml
+++ b/config/projects-ampad/wei-an-chen-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: wei-an-chen-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-dev/example-dev-project.yaml
+++ b/config/projects-dev/example-dev-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: example-dev-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-dev/mc2-mcmicro-dev-project.yaml
+++ b/config/projects-dev/mc2-mcmicro-dev-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: mc2-mcmicro-dev-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-dev/orca-dev-project.yaml
+++ b/config/projects-dev/orca-dev-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: orca-dev-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/amp-ad-project.yaml
+++ b/config/projects-prod/amp-ad-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: amp-ad-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/ctf-swnts-project.yaml
+++ b/config/projects-prod/ctf-swnts-project.yaml
@@ -41,7 +41,8 @@ parameters:
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
 
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/example-project.yaml
+++ b/config/projects-prod/example-project.yaml
@@ -47,7 +47,8 @@ parameters:
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
 
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/genie-bpc-project.yaml
+++ b/config/projects-prod/genie-bpc-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: genie-bpc-project
 
 dependencies:

--- a/config/projects-prod/htan-project.yaml
+++ b/config/projects-prod/htan-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: htan-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/iatlas-project.yaml
+++ b/config/projects-prod/iatlas-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: iatlas-project
 
 stack_tags:

--- a/config/projects-prod/imcore-project.yaml
+++ b/config/projects-prod/imcore-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: imcore-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/jhu-biobank-nf-project.yaml
+++ b/config/projects-prod/jhu-biobank-nf-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: jhu-biobank-nf-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/mc2-mcmicro-project.yaml
+++ b/config/projects-prod/mc2-mcmicro-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: mc2-mcmicro-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/nf-ntap5-biobank-jineta.yaml
+++ b/config/projects-prod/nf-ntap5-biobank-jineta.yaml
@@ -37,7 +37,8 @@ parameters:
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
 
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/nfri-ctf-nf1-project.yaml
+++ b/config/projects-prod/nfri-ctf-nf1-project.yaml
@@ -33,7 +33,8 @@ parameters:
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
 
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/ntap-add5-project.yaml
+++ b/config/projects-prod/ntap-add5-project.yaml
@@ -1,4 +1,5 @@
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 stack_name: ntap-add5-project
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/ntap-cnf-cell-project.yaml
+++ b/config/projects-prod/ntap-cnf-cell-project.yaml
@@ -32,7 +32,8 @@ parameters:
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
 
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/robert-allaway-project.yaml
+++ b/config/projects-prod/robert-allaway-project.yaml
@@ -40,7 +40,8 @@ parameters:
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
 
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/sophia-jobe-project.yaml
+++ b/config/projects-prod/sophia-jobe-project.yaml
@@ -39,7 +39,8 @@ parameters:
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
 
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/ucf-dod-nf2-project.yaml
+++ b/config/projects-prod/ucf-dod-nf2-project.yaml
@@ -33,7 +33,8 @@ parameters:
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
 
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 
 dependencies:
   - common/nextflow-forge-iam-policy.yaml

--- a/config/projects-prod/verena-chung-project.yaml
+++ b/config/projects-prod/verena-chung-project.yaml
@@ -39,7 +39,8 @@ parameters:
   TowerForgePolicyArn: !stack_output_external nextflow-forge-iam-policy::NextFlowForgePolicyArn
   TowerLaunchPolicyArn: !stack_output_external nextflow-launch-iam-policy::NextFlowLaunchPolicyArn
 
-template_path: tower-project.j2
+template:
+  path: tower-project.j2
 
 dependencies:
   - common/nextflow-forge-iam-policy.yaml


### PR DESCRIPTION
The Sceptre template_path key has been deprecated[1], update with the `template` key.

[1] https://docs.sceptre-project.org/dev/docs/stack_config.html?highlight=template_path#template-path