### PR TITLE
[IT-2376] Switch from LaunchConfiguration to LaunchTemplate

### DIFF
--- a/templates/nextflow-ecs-cluster.yaml
+++ b/templates/nextflow-ecs-cluster.yaml
@@ -190,7 +190,9 @@ Resources:
     Properties:
       VPCZoneIdentifier:
         - !Ref SubnetId
-      LaunchConfigurationName: !Ref EcsLaunchTemplate
+      LaunchTemplate:
+        LaunchTemplateId: !Ref EcsLaunchTemplate
+        Version: !GetAtt EcsLaunchTemplate.LatestVersionNumber
       MinSize: '0'
       MaxSize: !Ref AutoscalingGroupMaxSize
       DesiredCapacity: !Ref AutoscalingGroupDesiredCapacity

--- a/templates/nextflow-ecs-cluster.yaml
+++ b/templates/nextflow-ecs-cluster.yaml
@@ -117,38 +117,40 @@ Resources:
       RetentionInDays: 14
 
   EcsLaunchTemplate:
-    Type: AWS::AutoScaling::LaunchTemplate
+    Type: AWS::EC2::LaunchTemplate
     Properties:
-      ImageId: !Ref EcsAmiId
-      InstanceType: !Ref EcsInstanceType
-      IamInstanceProfile: !Ref EcsInstanceProfile
-      SecurityGroups:
-        - !Ref EcsSecurityGroupId
-      BlockDeviceMappings:
-        - DeviceName: !Ref RootDeviceName
-          Ebs:
-            VolumeSize: !Ref RootEbsVolumeSize
-            VolumeType: !Ref EbsVolumeType
-      UserData:
-        Fn::Base64: !Sub |
-          MIME-Version: 1.0
-          Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+      LaunchTemplateData:
+        ImageId: !Ref EcsAmiId
+        InstanceType: !Ref EcsInstanceType
+        IamInstanceProfile:
+          Arn: !GetAtt EcsInstanceProfile.Arn
+        SecurityGroupIds:
+          - !Ref EcsSecurityGroupId
+        BlockDeviceMappings:
+          - DeviceName: !Ref RootDeviceName
+            Ebs:
+              VolumeSize: !Ref RootEbsVolumeSize
+              VolumeType: !Ref EbsVolumeType
+        UserData:
+          Fn::Base64: !Sub |
+            MIME-Version: 1.0
+            Content-Type: multipart/mixed; boundary="==BOUNDARY=="
 
-          --==BOUNDARY==
-          Content-Type: text/cloud-config; charset="us-ascii"
+            --==BOUNDARY==
+            Content-Type: text/cloud-config; charset="us-ascii"
 
-          #cloud-config
-          repo_update: true
-          repo_upgrade: security
+            #cloud-config
+            repo_update: true
+            repo_upgrade: security
 
-          write_files:
-          - path: /etc/ecs/ecs.config
-            content: |
-              ECS_CLUSTER=${EcsClusterName}
-              ECS_IMAGE_PULL_BEHAVIOR=prefer-cached
-            append: true
+            write_files:
+            - path: /etc/ecs/ecs.config
+              content: |
+                ECS_CLUSTER=${EcsClusterName}
+                ECS_IMAGE_PULL_BEHAVIOR=prefer-cached
+              append: true
 
-          --==BOUNDARY==--
+            --==BOUNDARY==--
 
   EcsLaunchConfiguration:
     Type: AWS::AutoScaling::LaunchConfiguration

--- a/templates/nextflow-ecs-cluster.yaml
+++ b/templates/nextflow-ecs-cluster.yaml
@@ -116,6 +116,40 @@ Resources:
       LogGroupName: !Join ['-', [ECSLogGroup, !Ref 'AWS::StackName']]
       RetentionInDays: 14
 
+  EcsLaunchTemplate:
+    Type: AWS::AutoScaling::LaunchTemplate
+    Properties:
+      ImageId: !Ref EcsAmiId
+      InstanceType: !Ref EcsInstanceType
+      IamInstanceProfile: !Ref EcsInstanceProfile
+      SecurityGroups:
+        - !Ref EcsSecurityGroupId
+      BlockDeviceMappings:
+        - DeviceName: !Ref RootDeviceName
+          Ebs:
+            VolumeSize: !Ref RootEbsVolumeSize
+            VolumeType: !Ref EbsVolumeType
+      UserData:
+        Fn::Base64: !Sub |
+          MIME-Version: 1.0
+          Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+
+          --==BOUNDARY==
+          Content-Type: text/cloud-config; charset="us-ascii"
+
+          #cloud-config
+          repo_update: true
+          repo_upgrade: security
+
+          write_files:
+          - path: /etc/ecs/ecs.config
+            content: |
+              ECS_CLUSTER=${EcsClusterName}
+              ECS_IMAGE_PULL_BEHAVIOR=prefer-cached
+            append: true
+
+          --==BOUNDARY==--
+
   EcsLaunchConfiguration:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
@@ -156,7 +190,7 @@ Resources:
     Properties:
       VPCZoneIdentifier:
         - !Ref SubnetId
-      LaunchConfigurationName: !Ref EcsLaunchConfiguration
+      LaunchConfigurationName: !Ref EcsLaunchTemplate
       MinSize: '0'
       MaxSize: !Ref AutoscalingGroupMaxSize
       DesiredCapacity: !Ref AutoscalingGroupDesiredCapacity
@@ -192,6 +226,11 @@ Outputs:
     Value: !Ref EcsLaunchConfiguration
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsLaunchConfiguration'
+
+  EcsLaunchTemplateName:
+    Value: !Ref EcsLaunchTemplate
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-EcsLaunchTemplate'
 
   EcsAutoScalingGroupName:
     Value: !Ref EcsAutoScalingGroup


### PR DESCRIPTION
EC2 Launch configurations has been deprecated[1] in favor of LaunchTemplate.

[1] https://aws.amazon.com/blogs/compute/amazon-ec2-auto-scaling-will-no-longer-add-support-for-new-ec2-features-to-launch-configurations/