### PR TITLE
[WORKFLOWS-521] Check Redis append-only file first

### DIFF
--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -174,6 +174,8 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
+        # The following container definition is a stop-gap solution for
+        # https://sagebionetworks.jira.com/browse/WORKFLOWS-521
         - Name: !Sub '${RedisContainerName}-CheckAOF'
           Image: !Ref RedisContainerImage
           Memory: 2000

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -174,10 +174,30 @@ Resources:
           EFSVolumeConfiguration:
             FilesystemId: !Ref EfsFileSystemId
       ContainerDefinitions:
+        - Name: !Sub '${RedisContainerName}-CheckAOF'
+          Image: !Ref RedisContainerImage
+          Memory: 2000
+          Cpu: 0
+          EntryPoint:
+            - redis-check-aof
+          Command:
+            - --fix
+          MountPoints:
+            - ContainerPath: /data
+              SourceVolume: !Ref EfsVolumeName
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-region: !Sub '${AWS::Region}'
+              awslogs-group: !Ref TowerTaskLogGroup
+              awslogs-stream-prefix: !Ref AwslogsStreamPrefix
         - Name: !Ref RedisContainerName
           Image: !Ref RedisContainerImage
           Memory: 2000
           Cpu: 0
+          DependsOn:
+            - ContainerName: !Sub '${RedisContainerName}-CheckAOF'
+              Condition: SUCCESS
           PortMappings:
             - ContainerPort: 6379
               HostPort: 6379

--- a/templates/nextflow-ecs-task-definition.j2
+++ b/templates/nextflow-ecs-task-definition.j2
@@ -178,10 +178,14 @@ Resources:
           Image: !Ref RedisContainerImage
           Memory: 2000
           Cpu: 0
+          Essential: false
           EntryPoint:
-            - redis-check-aof
+            - /bin/sh
+          # The `yes` command is needed because `redis-check-aof` has an
+          # interactive prompt and doesn't have an option to disable it
           Command:
-            - --fix
+            - -c
+            - "yes | redis-check-aof --fix appendonly.aof"
           MountPoints:
             - ContainerPath: /data
               SourceVolume: !Ref EfsVolumeName


### PR DESCRIPTION
Now that we are persisting the Redis cache between deployments, we are running into corruption issues when we re-deploy Tower. This draft PR demonstrates one way of solving the issue, but I would prefer preventing it altogether. 

In this PR, we are automatically running the `redis-check-aof` command on launch (like the migrate database command) before launching Redis. I'm not sure if the behavior is defined if you have an existing Redis instance accessing this file while it's being fixed by another process. This is largely why I would prefer preventing this issue. 

**Edit:** I test this, and it seems to work. Also, Seqera didn't respond with anything particularly useful, so I'm okay with moving forward with this stop-gap solution until we work on a more permanent approach. 