### PR TITLE
Update the kms key template

### DIFF
--- a/templates/nextflow-aurora-mysql.yaml
+++ b/templates/nextflow-aurora-mysql.yaml
@@ -77,7 +77,7 @@ Resources:
     Condition: UseSnapshotFalse
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: !Sub ${TemplateRootUrl}/aws-infra/v0.2.19/KMS/kms-key.yaml
+      TemplateURL: !Sub ${TemplateRootUrl}/aws-infra/v0.6.83/KMS/kms-key.yaml
       TimeoutInMinutes: 5
       Parameters:
         AliasName: 'alias/nextflow-aurora-bootstrap-lambda'


### PR DESCRIPTION
Update the template used to create kms key to v0.6.83 which contains an KeyArn[1] as an output and more
expansive permission[2].  This will assist with the creation of downstream resources.

[1] Sage-Bionetworks/aws-infra@04c5b11
[2] Sage-Bionetworks/aws-infra@177f632