### PR TITLE
Bump AMP-AD budgets

### DIFF
--- a/src/sceptre/variables/ampad.yaml
+++ b/src/sceptre/variables/ampad.yaml
@@ -1,4 +1,4 @@
-compute_budget: "5000"
-storage_budget: "2000"
+compute_budget: "10000"
+storage_budget: "10000"
 security_budget: "500"
 other_budget: "500"


### PR DESCRIPTION
Due to heavy usage of the AMP-AD tower workspace, we are bumping the compute and storage costs up to 10k.