### PR TITLE
[IT-2790] Change release workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Execute jinja linter
         run: find . -type f -name "*.j2" -exec /tmp/jinja2-lint/j2lint.py '{}' +
   deploy-dev:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/dev'
     needs:
       - pre-commit
       - jinja-lint
@@ -43,8 +43,10 @@ jobs:
       sceptre-suffix: "dev"
       tower-url: "https://tower-dev.sagebionetworks.org"
   deploy-prod:
-    if: github.ref == 'refs/heads/main'
-    needs: deploy-dev
+    if: github.ref == 'refs/heads/prod'
+    needs:
+      - pre-commit
+      - jinja-lint
     uses: "./.github/workflows/rw-deploy.yaml"
     secrets: inherit
     with:
@@ -52,7 +54,7 @@ jobs:
       sceptre-suffix: "prod"
       tower-url: "https://tower.sagebionetworks.org"
   deploy-ampad:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/prod'
     needs: deploy-prod
     uses: "./.github/workflows/rw-deploy.yaml"
     secrets: inherit


### PR DESCRIPTION
Update github action deployment strategy to use a specific branch approach
  * deploy to nextflow dev only upon a merge to the `dev` branch
  * deploy to nextflow prod only upon a merge to the `prod`  branch
  * only deploy to ampad after a deployment to prod.

Todo after merging this PR:
  * create a `dev` and `prod` branch
  * delete the `main` branch

The new workflow will be:
  * Create PR targeting the `dev` branch
  * Review and approve PR
  * Merge to the dev branch
  * Deploy to nextflow dev
  * [Optional] Create PR for merge from dev  branch to prod branch 
  * [Optional] Review and approve PR
  * Merge dev branch to prod branch
  * Deploy to prod and ampad 

Note: Optional steps can be replaced with a direct push of the merge to the prod branch