### PR TITLE
[IT-2793] Fix pipenv cache in GH action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,10 @@ jobs:
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
       - name: Install dependencies
         run: pipenv install --dev
+
   validate:
+    runs-on: ubuntu-latest
+    steps:
       - name: Run pre-commit linters
         uses: pre-commit/action@v3.0.0
       # verify jinja templates
@@ -32,6 +35,7 @@ jobs:
         run: git clone --single-branch https://github.com/drm/jinja2-lint.git /tmp/jinja2-lint && pushd /tmp/jinja2-lint && git checkout 75dcd5a
       - name: Lint jinja templates
         run: find . -type f -name "*.j2" -exec /tmp/jinja2-lint/j2lint.py '{}' +
+
   deploy-dev:
     if: github.ref == 'refs/heads/main'
     needs:
@@ -42,6 +46,7 @@ jobs:
       job-environment: "workflows-nextflow-dev"
       sceptre-suffix: "dev"
       tower-url: "https://tower-dev.sagebionetworks.org"
+
   deploy-prod:
     if: github.ref == 'refs/heads/main'
     needs: deploy-dev
@@ -51,6 +56,7 @@ jobs:
       job-environment: "workflows-nextflow-prod"
       sceptre-suffix: "prod"
       tower-url: "https://tower.sagebionetworks.org"
+
   deploy-ampad:
     if: github.ref == 'refs/heads/main'
     needs: deploy-prod

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
       - '**.md'
 
 jobs:
-  prep-environment:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,10 +21,6 @@ jobs:
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
       - name: Install dependencies
         run: pipenv install --dev
-
-  validate:
-    runs-on: ubuntu-latest
-    steps:
       - name: Run pre-commit linters
         uses: pre-commit/action@v3.0.0
       # verify jinja templates

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,7 @@ jobs:
   prep-environment:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Set up python and cache
         uses: actions/setup-python@v4
         with:
@@ -21,7 +22,6 @@ jobs:
       - name: Install dependencies
         run: pipenv install --dev
   validate:
-      - uses: actions/checkout@v3
       - name: Run pre-commit linters
         uses: pre-commit/action@v3.0.0
       # verify jinja templates

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,34 +8,34 @@ on:
       - '**.md'
 
 jobs:
-  pre-commit:
+  prep-environment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - uses: pre-commit/action@v3.0.0
-  jinja-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
+      - name: Set up python and cache
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+          cache: 'pipenv'
+      - name: Install pipenv
+        run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
+      - name: Install dependencies
+        run: pipenv install --dev
+  validate:
+      - uses: actions/checkout@v3
+      - name: Run pre-commit linters
+        uses: pre-commit/action@v3.0.0
+      # verify jinja templates
       - name: Install jinja libraries
         run: |
           python -m pip install --upgrade jinja2==3.0.1
       - name: Install jinja linter tool
         run: git clone --single-branch https://github.com/drm/jinja2-lint.git /tmp/jinja2-lint && pushd /tmp/jinja2-lint && git checkout 75dcd5a
-      - name: Execute jinja linter
+      - name: Lint jinja templates
         run: find . -type f -name "*.j2" -exec /tmp/jinja2-lint/j2lint.py '{}' +
   deploy-dev:
     if: github.ref == 'refs/heads/main'
     needs:
-      - pre-commit
-      - jinja-lint
+      - validate
     uses: "./.github/workflows/rw-deploy.yaml"
     secrets: inherit
     with:

--- a/.github/workflows/rw-deploy.yaml
+++ b/.github/workflows/rw-deploy.yaml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.job-environment }}
     steps:
-
       - name: Checkout repository
         uses: actions/checkout@v3
 
@@ -26,12 +25,6 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pipenv'
-
-      - name: Install pipenv
-        run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
-
-      - name: Install dependencies
-        run: pipenv install --dev
 
       - name: Assume AWS role in dev account
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/rw-deploy.yaml
+++ b/.github/workflows/rw-deploy.yaml
@@ -25,26 +25,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+          cache: 'pipenv'
 
       - name: Install pipenv
-        run: python -m pip install pipenv
-
-      - name: Set up dependency caching
-        uses: actions/cache@v2
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-pipenv-v2-${{ hashFiles('**/Pipfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pipenv-v2-
+        run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
 
       - name: Install dependencies
-        if: steps.pipenv-cache.outputs.cache-hit != 'true'
-        env:
-          PIPENV_NOSPIN: 'true'
-          WORKON_HOME: ~/.local/share/virtualenvs
-          PIPENV_CACHE_DIR: ~/.local/share/pipcache
-        run: |
-          pipenv install --dev
+        run: pipenv install --dev
 
       - name: Assume AWS role in dev account
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
This is an update to use setup-python action to cache pipenv[1]
dependencies. Hopefully this will also fix the pipenv caching problem
we've been seeing recently.  This also moves `pipenv install` from the
deploy pipeline to the validation pipeline thus testing dependencies
sooner in the CI workflow.

[1] https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages
